### PR TITLE
🖥️ Add machine start, stop and status page.

### DIFF
--- a/src/Machine.css
+++ b/src/Machine.css
@@ -1,0 +1,17 @@
+.Machine {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+
+.Machine-label {
+    font-size: 8rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+.Machine-label--loading {
+    cursor: default;
+    opacity: 0.4;
+}

--- a/src/Machine.tsx
+++ b/src/Machine.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react'
+import { useAuth, useInterval } from './Hooks'
+import './Machine.css'
+
+type MachineState = 'running' | 'stopped' | 'pending' | 'stopping' | 'starting' | null
+
+const TRANSITIONING: MachineState[] = ['pending', 'stopping', 'starting']
+
+const banditHost = import.meta.env.VITE_API_HOST
+
+const Machine = () => {
+    const { user } = useAuth()
+    const [state, setState] = useState<MachineState>(null)
+
+    const fetchStatus = async () => {
+        try {
+            const response = await fetch(`${banditHost}/machine/status`, {
+                headers: { Authorization: user.token },
+            })
+            const json = await response.json()
+            setState(json.state)
+        } catch (error) {
+            console.log(error)
+        }
+    }
+
+    useEffect(() => {
+        fetchStatus()
+    }, [])
+
+    const isTransitioning = state !== null && TRANSITIONING.includes(state)
+
+    useInterval(fetchStatus, isTransitioning ? 5000 : null)
+
+    const handleAction = async () => {
+        if (state === 'running') {
+            setState('stopping')
+            await fetch(`${banditHost}/machine/stop`, {
+                method: 'POST',
+                headers: { Authorization: user.token },
+            })
+        } else if (state === 'stopped') {
+            setState('starting')
+            await fetch(`${banditHost}/machine/start`, {
+                method: 'POST',
+                headers: { Authorization: user.token },
+            })
+        }
+    }
+
+    const label = () => {
+        if (state === 'running') return 'Stop'
+        if (state === 'stopped') return 'Start'
+        if (state) return `${state}...`
+        return '...'
+    }
+
+    return (
+        <div className="Machine">
+            <span
+                className={`Machine-label${isTransitioning ? ' Machine-label--loading' : ''}`}
+                onClick={isTransitioning ? undefined : handleAction}
+            >
+                {label()}
+            </span>
+        </div>
+    )
+}
+
+export default Machine

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ const Album = lazy(() => import('./Album'))
 const Login = lazy(() => import('./Login'))
 const Flyer = lazy(() => import('./Flyer'))
 const Days = lazy(() => import('./Days'))
+const Machine = lazy(() => import('./Machine'))
 import ProtectedRoute from './ProtectedRoute'
 import { AuthProvider } from './Hooks'
 import { CalendarProvider } from './CalendarContext'
@@ -74,6 +75,15 @@ if (host.length && host[0] === 'blog') {
                                 />
 
                                 <Route path="/login" element={<Login />} />
+
+                                <Route
+                                    path="/machine"
+                                    element={
+                                        <ProtectedRoute>
+                                            <Machine />
+                                        </ProtectedRoute>
+                                    }
+                                />
                             </Routes>
                         </div>
                     </CalendarProvider>


### PR DESCRIPTION
## Summary
- Adds `/machine` route behind `ProtectedRoute`
- Big Start/Stop label centered on the screen, clickable to toggle the EC2 instance
- Shows transitioning state (`starting...`, `stopping...`) with reduced opacity while polling every 5s for status updates
- Polling pauses automatically when the instance reaches a stable state