### PR TITLE
🔐 Machine UI, Google One Tap auth and extensible loader.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "home-sweet",
             "version": "0.1.0",
             "dependencies": {
+                "@react-oauth/google": "^0.13.5",
                 "@tensorflow-models/blazeface": "^0.0.7",
                 "@tensorflow/tfjs": "^3.19.0",
                 "@types/d3": "^6.2.0",
@@ -800,6 +801,16 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@react-oauth/google": {
+            "version": "0.13.5",
+            "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+            "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
             }
         },
         "node_modules/@remix-run/router": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
+        "@react-oauth/google": "^0.13.5",
         "@tensorflow-models/blazeface": "^0.0.7",
         "@tensorflow/tfjs": "^3.19.0",
         "@types/d3": "^6.2.0",

--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -88,7 +88,6 @@ export function useLocalStorage(key, initialValue) {
     return [storedValue, setValue]
 }
 
-
 export function useDebounce(value, delay) {
     const [debouncedValue, setDebouncedValue] = useState(value)
 
@@ -105,12 +104,14 @@ export function useDebounce(value, delay) {
     return debouncedValue
 }
 
-
-
 export function useViewport() {
-    const [size, setSize] = useState({ width: window.innerWidth, height: window.innerHeight })
+    const [size, setSize] = useState({
+        width: window.innerWidth,
+        height: window.innerHeight,
+    })
     useEffect(() => {
-        const handler = () => setSize({ width: window.innerWidth, height: window.innerHeight })
+        const handler = () =>
+            setSize({ width: window.innerWidth, height: window.innerHeight })
         window.addEventListener('resize', handler)
         return () => window.removeEventListener('resize', handler)
     }, [])
@@ -123,10 +124,8 @@ export const AuthProvider = ({ children }) => {
     const [user, setUser] = useLocalStorage('user', null)
     const navigate = useNavigate()
 
-    // call this function when you want to authenticate the user
     const login = async (data) => {
         setUser(data)
-        navigate('/calendar')
     }
 
     // call this function to sign out logged in user

--- a/src/LoaderBraille.css
+++ b/src/LoaderBraille.css
@@ -1,0 +1,12 @@
+.LoaderBraille {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+
+.LoaderBraille-frame {
+    font-family: 'ocr-a-std', monospace;
+    font-size: 8rem;
+    color: magenta;
+}

--- a/src/LoaderBraille.tsx
+++ b/src/LoaderBraille.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+import { useInterval } from './Hooks'
+import './LoaderBraille.css'
+
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
+const LoaderBraille = () => {
+    const [index, setIndex] = useState(0)
+
+    useInterval(() => {
+        setIndex((i) => (i + 1) % FRAMES.length)
+    }, 80)
+
+    return (
+        <div className="LoaderBraille">
+            <span className="LoaderBraille-frame">{FRAMES[index]}</span>
+        </div>
+    )
+}
+
+export default LoaderBraille

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,60 +1,33 @@
-import { useState, useEffect, ChangeEvent } from 'react'
+import { useGoogleOneTapLogin } from '@react-oauth/google'
 import { useAuth } from './Hooks'
-import './Login.css'
 
 const banditHost = import.meta.env.VITE_API_HOST
 
-export const Login = () => {
-    const { login, logout } = useAuth()
-    let [password, setPassword] = useState<string>('')
+const Login = () => {
+    const { login } = useAuth()
 
-    const handleClick = () => {
-        const getToken = async (url: string) => {
+    useGoogleOneTapLogin({
+        onSuccess: async (credentialResponse) => {
             try {
-                let payload = {
+                const response = await fetch(`${banditHost}/login`, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
+                    headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        password: password,
+                        credential: credentialResponse.credential,
                     }),
-                }
-
-                let response = await fetch(url, payload)
-                let json = await response.json()
-
+                })
+                const json = await response.json()
                 if (json.token) {
-                    console.log(json.token)
-                    login({
-                        token: json.token,
-                    })
+                    login({ token: json.token, roles: json.roles })
                 }
-                
-
-                
             } catch (error) {
                 console.log(error)
             }
-        }
+        },
+        onError: () => console.log('Google login failed'),
+    })
 
-        getToken(banditHost + '/login')
-    }
-
-    const handleLogout = () => {
-        logout()
-    }
-
-    const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
-        setPassword(e.target.value)
-    }
-
-    return (
-        <div className="Login">
-            <input type="password" id="password" onChange={handleOnChange}></input>
-            <button onClick={handleClick}>login</button>
-        </div>
-    )
+    return null
 }
 
 export default Login

--- a/src/Machine.css
+++ b/src/Machine.css
@@ -9,9 +9,6 @@
     font-size: 8rem;
     cursor: pointer;
     user-select: none;
-}
-
-.Machine-label--loading {
-    cursor: default;
-    opacity: 0.4;
+    font-family: 'LubalinGraphStd-Medium', serif;
+    color: magenta;
 }

--- a/src/Machine.css
+++ b/src/Machine.css
@@ -1,0 +1,17 @@
+.Machine {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+
+.Machine-label {
+    font-size: 8rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+.Machine-label--loading {
+    cursor: default;
+    opacity: 0.4;
+}

--- a/src/Machine.tsx
+++ b/src/Machine.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react'
+import { useAuth, useInterval } from './Hooks'
+import './Machine.css'
+
+type MachineState = 'running' | 'stopped' | 'pending' | 'stopping' | 'starting' | null
+
+const TRANSITIONING: MachineState[] = ['pending', 'stopping', 'starting']
+
+const banditHost = import.meta.env.VITE_API_HOST
+
+const Machine = () => {
+    const { user } = useAuth()
+    const [state, setState] = useState<MachineState>(null)
+
+    const fetchStatus = async () => {
+        try {
+            const response = await fetch(`${banditHost}/machine/status`, {
+                headers: { Authorization: user.token },
+            })
+            const json = await response.json()
+            setState(json.state)
+        } catch (error) {
+            console.log(error)
+        }
+    }
+
+    useEffect(() => {
+        fetchStatus()
+    }, [])
+
+    const isTransitioning = state !== null && TRANSITIONING.includes(state)
+
+    useInterval(fetchStatus, isTransitioning ? 5000 : null)
+
+    const handleAction = async () => {
+        if (state === 'running') {
+            setState('stopping')
+            await fetch(`${banditHost}/machine/stop`, {
+                method: 'POST',
+                headers: { Authorization: user.token },
+            })
+        } else if (state === 'stopped') {
+            setState('starting')
+            await fetch(`${banditHost}/machine/start`, {
+                method: 'POST',
+                headers: { Authorization: user.token },
+            })
+        }
+    }
+
+    const label = () => {
+        if (state === 'running') return 'Stop'
+        if (state === 'stopped') return 'Start'
+        if (state) return `${state}...`
+        return '...'
+    }
+
+    return (
+        <div className="Machine">
+            <span
+                className={`Machine-label${isTransitioning ? ' Machine-label--loading' : ''}`}
+                onClick={isTransitioning ? undefined : handleAction}
+            >
+                {label()}
+            </span>
+        </div>
+    )
+}
+
+export default Machine

--- a/src/Machine.tsx
+++ b/src/Machine.tsx
@@ -1,8 +1,15 @@
 import { useState, useEffect } from 'react'
 import { useAuth, useInterval } from './Hooks'
+import Spinner from './Spinner'
 import './Machine.css'
 
-type MachineState = 'running' | 'stopped' | 'pending' | 'stopping' | 'starting' | null
+type MachineState =
+    | 'running'
+    | 'stopped'
+    | 'pending'
+    | 'stopping'
+    | 'starting'
+    | null
 
 const TRANSITIONING: MachineState[] = ['pending', 'stopping', 'starting']
 
@@ -30,7 +37,7 @@ const Machine = () => {
 
     const isTransitioning = state !== null && TRANSITIONING.includes(state)
 
-    useInterval(fetchStatus, isTransitioning ? 5000 : null)
+    useInterval(fetchStatus, isTransitioning ? 2500 : null)
 
     const handleAction = async () => {
         if (state === 'running') {
@@ -49,17 +56,23 @@ const Machine = () => {
     }
 
     const label = () => {
+        if (isTransitioning || state === null) return <Spinner />
         if (state === 'running') return 'Stop'
-        if (state === 'stopped') return 'Start'
-        if (state) return `${state}...`
-        return '...'
+        return 'Start'
     }
 
     return (
         <div className="Machine">
             <span
-                className={`Machine-label${isTransitioning ? ' Machine-label--loading' : ''}`}
-                onClick={isTransitioning ? undefined : handleAction}
+                className="Machine-label"
+                onClick={
+                    isTransitioning || state === null ? undefined : handleAction
+                }
+                style={
+                    isTransitioning || state === null
+                        ? { cursor: 'default' }
+                        : undefined
+                }
             >
                 {label()}
             </span>

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,11 +1,37 @@
-import { Navigate } from 'react-router-dom'
 import { useAuth } from './Hooks'
+import Login from './Login'
 
-const ProtectedRoute = ({ children }) => {
-    // This classed is based of https://blog.logrocket.com/complete-guide-authentication-with-react-router-v6/
+interface Props {
+    children: React.ReactNode
+    requiredRole?: string
+}
+
+const hasRole = (roles: string[], requiredRole: string): boolean => {
+    if (requiredRole === 'owner') return roles.includes('owner')
+    return roles.includes(requiredRole) || roles.includes('owner')
+}
+
+const ProtectedRoute = ({ children, requiredRole }: Props) => {
     const { user } = useAuth()
-    if (!user) {
-        return <Navigate to="/login" />
+
+    if (!user) return <Login />
+
+    if (requiredRole && !hasRole(user.roles ?? [], requiredRole)) {
+        return (
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100vh',
+                    fontFamily: "'LubalinGraphStd-Medium', serif",
+                    fontSize: '4rem',
+                    color: 'magenta',
+                }}
+            >
+                not for you
+            </div>
+        )
     }
 
     return children

--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -1,0 +1,14 @@
+import { useState } from 'react'
+import Loader from './Loader'
+import LoaderBraille from './LoaderBraille'
+
+const LOADERS = [Loader, LoaderBraille]
+
+const Spinner = () => {
+    const [Component] = useState(
+        () => LOADERS[Math.floor(Math.random() * LOADERS.length)]
+    )
+    return <Component />
+}
+
+export default Spinner

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import './fonts/LubalinGraphStd-Medium/font.woff'
 import './fonts/LubalinGraphStd-Medium/font.woff2'
 import { BrowserRouter as Router } from 'react-router-dom'
 import { Routes, Route } from 'react-router-dom'
+import { GoogleOAuthProvider } from '@react-oauth/google'
 
 const Scaffold = lazy(() => import('./Scaffold'))
 const About = lazy(() => import('./About'))
@@ -13,88 +14,89 @@ const Names = lazy(() => import('./Names'))
 const Post = lazy(() => import('./Post'))
 const Calendar = lazy(() => import('./Calendar'))
 const Album = lazy(() => import('./Album'))
-const Login = lazy(() => import('./Login'))
 const Flyer = lazy(() => import('./Flyer'))
 const Days = lazy(() => import('./Days'))
 const Machine = lazy(() => import('./Machine'))
 import ProtectedRoute from './ProtectedRoute'
 import { AuthProvider } from './Hooks'
 import { CalendarProvider } from './CalendarContext'
+import Spinner from './Spinner'
 
 const root = createRoot(document.getElementById('root'))
 
 let host = window.location.host.split('.')
 
 const banditHost = import.meta.env.VITE_API_HOST
+const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID
 
 if (host.length && host[0] === 'blog') {
     root.render(
-        <Router>
-            <Suspense fallback={null}>
-                <AuthProvider>
-                    <CalendarProvider>
-                        <div className="Blog">
-                            <Routes>
-                                <Route
-                                    path="/"
-                                    element={
-                                        <Blog
-                                            title={'Else'}
-                                            url={`${banditHost}/posts`}
-                                        />
-                                    }
-                                />
+        <GoogleOAuthProvider clientId={googleClientId}>
+            <Router>
+                <Suspense fallback={<Spinner />}>
+                    <AuthProvider>
+                        <CalendarProvider>
+                            <div className="Blog">
+                                <Routes>
+                                    <Route
+                                        path="/"
+                                        element={
+                                            <Blog
+                                                title={'Else'}
+                                                url={`${banditHost}/posts`}
+                                            />
+                                        }
+                                    />
 
-                                <Route
-                                    path="/post/:slug"
-                                    element={
-                                        <Post url={`${banditHost}/post`} />
-                                    }
-                                />
+                                    <Route
+                                        path="/post/:slug"
+                                        element={
+                                            <Post url={`${banditHost}/post`} />
+                                        }
+                                    />
 
-                                <Route path="/invite" element={<Flyer />} />
+                                    <Route path="/invite" element={<Flyer />} />
 
-                                <Route path="/days" element={<Days />} />
+                                    <Route path="/days" element={<Days />} />
 
-                                <Route
-                                    path="/calendar"
-                                    element={
-                                        <ProtectedRoute>
-                                            <Calendar />
-                                        </ProtectedRoute>
-                                    }
-                                />
+                                    <Route
+                                        path="/calendar"
+                                        element={
+                                            <ProtectedRoute requiredRole="family">
+                                                <Calendar />
+                                            </ProtectedRoute>
+                                        }
+                                    />
 
-                                <Route
-                                    path="/calendar/:year/:month/:day"
-                                    element={
-                                        <ProtectedRoute>
-                                            <Album />
-                                        </ProtectedRoute>
-                                    }
-                                />
+                                    <Route
+                                        path="/calendar/:year/:month/:day"
+                                        element={
+                                            <ProtectedRoute requiredRole="family">
+                                                <Album />
+                                            </ProtectedRoute>
+                                        }
+                                    />
 
-                                <Route path="/login" element={<Login />} />
-
-                                <Route
-                                    path="/machine"
-                                    element={
-                                        <ProtectedRoute>
-                                            <Machine />
-                                        </ProtectedRoute>
-                                    }
-                                />
-                            </Routes>
-                        </div>
-                    </CalendarProvider>
-                </AuthProvider>
-            </Suspense>
-        </Router>
+                                    <Route
+                                        path="/machine"
+                                        element={
+                                            <ProtectedRoute requiredRole="owner">
+                                                <Machine />
+                                            </ProtectedRoute>
+                                        }
+                                    />
+                                </Routes>
+                            </div>
+                        </CalendarProvider>
+                    </AuthProvider>
+                </Suspense>
+            </Router>
+        </GoogleOAuthProvider>
     )
 } else if (host.length && host[0] === 'calendar') {
     root.render(
         <Router>
-            <Suspense fallback={null}>
+            <Suspense fallback={<Spinner />}>
                 <Calendar />
             </Suspense>
         </Router>
@@ -102,17 +104,29 @@ if (host.length && host[0] === 'blog') {
 } else if (host.length && host[0] === 'into') {
     root.render(
         <Router>
-            <Suspense fallback={null}>
+            <Suspense fallback={<Spinner />}>
                 <div className="Blog">
                     <About />
                 </div>
             </Suspense>
         </Router>
     )
+} else if (host.length && host[0] === 'do') {
+    root.render(
+        <GoogleOAuthProvider clientId={googleClientId}>
+            <Router>
+                <Suspense fallback={<Spinner />}>
+                    <AuthProvider>
+                        <About />
+                    </AuthProvider>
+                </Suspense>
+            </Router>
+        </GoogleOAuthProvider>
+    )
 } else if (host.length && host[0] === 'poroto') {
     root.render(
         <Router>
-            <Suspense fallback={null}>
+            <Suspense fallback={<Spinner />}>
                 <div className="Blog">
                     <Names />
                 </div>
@@ -122,7 +136,7 @@ if (host.length && host[0] === 'blog') {
 } else if (host.length && host[0] === 'baby') {
     root.render(
         <Router>
-            <Suspense fallback={null}>
+            <Suspense fallback={<Spinner />}>
                 <Flyer />
             </Suspense>
         </Router>
@@ -130,7 +144,7 @@ if (host.length && host[0] === 'blog') {
 } else {
     root.render(
         <Router>
-            <Suspense fallback={null}>
+            <Suspense fallback={<Spinner />}>
                 <Scaffold />
             </Suspense>
         </Router>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ const Album = lazy(() => import('./Album'))
 const Login = lazy(() => import('./Login'))
 const Flyer = lazy(() => import('./Flyer'))
 const Days = lazy(() => import('./Days'))
+const Machine = lazy(() => import('./Machine'))
 import ProtectedRoute from './ProtectedRoute'
 import { AuthProvider } from './Hooks'
 import { CalendarProvider } from './CalendarContext'
@@ -74,6 +75,15 @@ if (host.length && host[0] === 'blog') {
                                 />
 
                                 <Route path="/login" element={<Login />} />
+
+                                <Route
+                                    path="/machine"
+                                    element={
+                                        <ProtectedRoute>
+                                            <Machine />
+                                        </ProtectedRoute>
+                                    }
+                                />
                             </Routes>
                         </div>
                     </CalendarProvider>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,21 +1,30 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+    readonly VITE_API_HOST: string
+    readonly VITE_GOOGLE_CLIENT_ID: string
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv
+}
+
 declare module '*.jpg' {
-  const src: string
-  export default src
+    const src: string
+    export default src
 }
 
 declare module '*.png' {
-  const src: string
-  export default src
+    const src: string
+    export default src
 }
 
 declare module '*.woff' {
-  const src: string
-  export default src
+    const src: string
+    export default src
 }
 
 declare module '*.woff2' {
-  const src: string
-  export default src
+    const src: string
+    export default src
 }


### PR DESCRIPTION
## Summary
- Add Machine page with Lubalin magenta styling and 2.5s polling
- Replace password login with Google One Tap, fires automatically on protected routes
- Role-aware ProtectedRoute, renders inline with "not for you" on wrong role
- Extensible Spinner registry with ASCII torus knot and braille variants
- Add do.then.gallery subdomain, remove /login route

## Test plan
- [ ] Navigate to /machine → Google One Tap fires automatically
- [ ] After login, Machine page loads without URL change
- [ ] Family user hitting /machine → "not for you" message
- [ ] Spinner picks randomly between ASCII torus knot and braille