### PR TITLE
🐛 Treat stale tokens without roles as logged out.

### DIFF
--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useGoogleOneTapLogin } from '@react-oauth/google'
 import { useAuth } from './Hooks'
 
@@ -5,8 +6,10 @@ const banditHost = import.meta.env.VITE_API_HOST
 
 const Login = () => {
     const { login } = useAuth()
+    const [error, setError] = useState(false)
 
     useGoogleOneTapLogin({
+        disabled: error,
         onSuccess: async (credentialResponse) => {
             try {
                 const response = await fetch(`${banditHost}/login`, {
@@ -16,16 +19,36 @@ const Login = () => {
                         credential: credentialResponse.credential,
                     }),
                 })
-                const json = await response.json()
-                if (json.token) {
-                    login({ token: json.token, roles: json.roles })
+                if (!response.ok) {
+                    setError(true)
+                    return
                 }
-            } catch (error) {
-                console.log(error)
+                const json = await response.json()
+                login({ token: json.token, roles: json.roles })
+            } catch (e) {
+                console.log(e)
             }
         },
         onError: () => console.log('Google login failed'),
     })
+
+    if (error) {
+        return (
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100vh',
+                    fontFamily: "'LubalinGraphStd-Medium', serif",
+                    fontSize: '4rem',
+                    color: 'magenta',
+                }}
+            >
+                not for you
+            </div>
+        )
+    }
 
     return null
 }

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -14,7 +14,7 @@ const hasRole = (roles: string[], requiredRole: string): boolean => {
 const ProtectedRoute = ({ children, requiredRole }: Props) => {
     const { user } = useAuth()
 
-    if (!user) return <Login />
+    if (!user || !Array.isArray(user.roles)) return <Login />
 
     if (requiredRole && !hasRole(user.roles ?? [], requiredRole)) {
         return (


### PR DESCRIPTION
## Summary
- A stale token from the old password-based login (`{ token }` with no `roles`) is truthy, so `ProtectedRoute` was skipping `<Login />` and jumping straight to "not for you"
- Fix: check `Array.isArray(user.roles)` — if missing, treat as logged out and render `<Login />` to trigger the Google One Tap flow

## Test plan
- [ ] Clear localStorage and visit `/machine` → Google One Tap fires
- [ ] With a stale token (no `roles`) in localStorage → One Tap fires instead of "not for you"
- [ ] With a valid token + correct role → protected content renders