### PR TITLE
🐣 Consolidate poroto subdomain with menu, add auth, remove baby subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ VITE_GOOGLE_CLIENT_ID=  # Google OAuth client ID (needed for blog/machine auth)
 Add the following to `/etc/hosts` to enable subdomain routing locally:
 
 ```
-127.0.0.1 blog.localhost calendar.localhost into.localhost poroto.localhost baby.localhost machine.localhost
+127.0.0.1 blog.localhost calendar.localhost into.localhost poroto.localhost machine.localhost
 ```
 
 Run the dev server:
@@ -120,8 +120,7 @@ Subdomains are accessible at:
 -   `http://blog.localhost:5173` — blog + calendar
 -   `http://calendar.localhost:5173` — calendar
 -   `http://into.localhost:5173` — about
--   `http://poroto.localhost:5173` — names
--   `http://baby.localhost:5173` — flyer
+-   `http://poroto.localhost:5173` — poroto (requires owner auth): names, flyer
 -   `http://machine.localhost:5173` — machine (requires owner auth)
 
 ---

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,12 +7,22 @@ const displayNames = {
     '/autostereogram': 'magic eye',
 }
 
-const Menu = (props) => {
+const defaultLinkTo = (option: string) => `/bit${option}`
+const noop = () => {}
+
+const Menu = (props: {
+    options: string[]
+    setIndexBackground?: (key: string) => void
+    linkTo?: (option: string) => string
+    style?: React.CSSProperties
+}) => {
     const listRef = useRef<HTMLUListElement>(null)
     const [activeIndex, setActiveIndex] = useState(0)
+    const setIndexBackground = props.setIndexBackground ?? noop
+    const linkTo = props.linkTo ?? defaultLinkTo
 
     useEffect(() => {
-        props.setIndexBackground(props.options[0])
+        setIndexBackground(props.options[0])
     }, [])
 
     useEffect(() => {
@@ -24,18 +34,24 @@ const Menu = (props) => {
             ticking = true
             requestAnimationFrame(() => {
                 const items = listRef.current?.querySelectorAll('li')
-                if (!items) { ticking = false; return }
+                if (!items) {
+                    ticking = false
+                    return
+                }
                 const center = window.innerHeight / 2
                 let closest = 0
                 let minDist = Infinity
                 items.forEach((li, i) => {
                     const rect = li.getBoundingClientRect()
                     const dist = Math.abs(rect.top + rect.height / 2 - center)
-                    if (dist < minDist) { minDist = dist; closest = i }
+                    if (dist < minDist) {
+                        minDist = dist
+                        closest = i
+                    }
                 })
                 if (closest !== activeIndex) {
                     setActiveIndex(closest)
-                    props.setIndexBackground(props.options[closest])
+                    setIndexBackground(props.options[closest])
                 }
                 ticking = false
             })
@@ -47,11 +63,15 @@ const Menu = (props) => {
     }, [activeIndex, props.options])
 
     return (
-        <ul className="Menu" ref={listRef}>
+        <ul className="Menu" ref={listRef} style={props.style}>
             {props.options.map((element, index) => (
-                <li key={index} className={index === activeIndex ? 'active' : ''}>
-                    <Link to={`/bit${element}`}>
-                        {displayNames[element] || element.slice(1).replace('-', ' ')}
+                <li
+                    key={index}
+                    className={index === activeIndex ? 'active' : ''}
+                >
+                    <Link to={linkTo(element)}>
+                        {displayNames[element] ||
+                            element.slice(1).replace('-', ' ')}
                     </Link>
                 </li>
             ))}

--- a/src/Poroto.tsx
+++ b/src/Poroto.tsx
@@ -1,0 +1,24 @@
+import React, { lazy, Suspense } from 'react'
+import { Routes, Route } from 'react-router-dom'
+import Menu from './Menu'
+import Spinner from './Spinner'
+
+const Names = lazy(() => import('./Names'))
+const Flyer = lazy(() => import('./Flyer'))
+
+const options = ['/names', '/flyer']
+const linkTo = (option: string) => option
+
+const PorotoMenu = () => <Menu options={options} linkTo={linkTo} />
+
+const Poroto = () => (
+    <Suspense fallback={<Spinner />}>
+        <Routes>
+            <Route path="/" element={<PorotoMenu />} />
+            <Route path="/names" element={<Names />} />
+            <Route path="/flyer" element={<Flyer />} />
+        </Routes>
+    </Suspense>
+)
+
+export default Poroto

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import { GoogleOAuthProvider } from '@react-oauth/google'
 const Scaffold = lazy(() => import('./Scaffold'))
 const About = lazy(() => import('./About'))
 const Blog = lazy(() => import('./Blog'))
-const Names = lazy(() => import('./Names'))
+const Poroto = lazy(() => import('./Poroto'))
 const Post = lazy(() => import('./Post'))
 const Calendar = lazy(() => import('./Calendar'))
 const Album = lazy(() => import('./Album'))
@@ -118,21 +118,17 @@ if (host.length && host[0] === 'blog') {
     )
 } else if (host.length && host[0] === 'poroto') {
     root.render(
-        <Router>
-            <Suspense fallback={<Spinner />}>
-                <div className="Blog">
-                    <Names />
-                </div>
-            </Suspense>
-        </Router>
-    )
-} else if (host.length && host[0] === 'baby') {
-    root.render(
-        <Router>
-            <Suspense fallback={<Spinner />}>
-                <Flyer />
-            </Suspense>
-        </Router>
+        <GoogleOAuthProvider clientId={googleClientId}>
+            <Router>
+                <Suspense fallback={<Spinner />}>
+                    <AuthProvider>
+                        <ProtectedRoute requiredRole="owner">
+                            <Poroto />
+                        </ProtectedRoute>
+                    </AuthProvider>
+                </Suspense>
+            </Router>
+        </GoogleOAuthProvider>
     )
 } else {
     root.render(


### PR DESCRIPTION
## Summary
- Refactors \`Menu\` to accept optional \`setIndexBackground\` and a \`linkTo\` prop, making it reusable outside the main app
- Adds \`Poroto.tsx\`: auth-protected subdomain with a scroll-snap menu routing to \`/names\` and \`/flyer\`
- Removes the \`baby\` subdomain handler from \`index.tsx\`
- Updates \`README.md\` to reflect the new subdomain structure