### PR TITLE
🎨✨ Fix spinner centering and replace double-click with long-press on Machine IP

### DIFF
--- a/src/LoaderBraille.css
+++ b/src/LoaderBraille.css
@@ -1,12 +1,14 @@
 .LoaderBraille {
+    position: fixed;
+    inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 100vh;
 }
 
 .LoaderBraille-frame {
     font-family: 'ocr-a-std', monospace;
     font-size: 8rem;
+    line-height: 1;
     color: magenta;
 }

--- a/src/Machine.css
+++ b/src/Machine.css
@@ -30,7 +30,6 @@
 }
 
 .Machine-info-ip {
-    user-select: text;
     cursor: copy;
     transition: color 0.1s ease, opacity 0.3s ease;
 }

--- a/src/Machine.tsx
+++ b/src/Machine.tsx
@@ -37,13 +37,23 @@ const Machine = () => {
 
     const [copied, setCopied] = useState(false)
     const copyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-    const handleCopyIp = () => {
+    const handlePressStart = () => {
         if (!info?.publicIp) return
-        navigator.clipboard.writeText(info.publicIp)
-        setCopied(true)
-        if (copyTimeout.current) clearTimeout(copyTimeout.current)
-        copyTimeout.current = setTimeout(() => setCopied(false), 1500)
+        longPressTimer.current = setTimeout(() => {
+            navigator.clipboard.writeText(info.publicIp)
+            setCopied(true)
+            if (copyTimeout.current) clearTimeout(copyTimeout.current)
+            copyTimeout.current = setTimeout(() => setCopied(false), 500)
+        }, 1000)
+    }
+
+    const handlePressEnd = () => {
+        if (longPressTimer.current) {
+            clearTimeout(longPressTimer.current)
+            longPressTimer.current = null
+        }
     }
 
     const fetchStatus = async () => {
@@ -120,8 +130,15 @@ const Machine = () => {
                         className={`Machine-info-ip${
                             copied ? ' Machine-info-ip--copied' : ''
                         }`}
-                        onDoubleClick={handleCopyIp}
-                        title="Double-click to copy"
+                        onMouseDown={(e) => {
+                            e.preventDefault()
+                            handlePressStart()
+                        }}
+                        onMouseUp={handlePressEnd}
+                        onMouseLeave={handlePressEnd}
+                        onTouchStart={handlePressStart}
+                        onTouchEnd={handlePressEnd}
+                        title="Hold to copy"
                     >
                         {info.publicIp}
                     </span>


### PR DESCRIPTION
## Summary

- Fix `LoaderBraille` spinner not being centered on screen — switched from `height: 100vh` to `position: fixed; inset: 0` for reliable viewport centering, and added `line-height: 1` to eliminate extra whitespace below the Braille glyph
- Replace double-click with long-press (1s hold) to copy the public IP in the Machine component — more intuitive on both desktop and touch
- Reduce copy feedback duration from 1.5s to 0.5s for snappier feel

## Test plan

- [ ] Trigger the `LoaderBraille` spinner and verify it appears centered on screen
- [ ] On the Machine screen with a running instance, hold the IP for 1 second and verify it copies to clipboard
- [ ] Verify releasing before 1 second does not trigger a copy
- [ ] Verify the copied feedback (color change) disappears after ~0.5s