### PR TITLE
✨ Trigger Konami theme by rapid-toggling the switch

### DIFF
--- a/src/Scaffold.tsx
+++ b/src/Scaffold.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useLocalStorage } from './Hooks'
 import Home from './Home'
 import { getRandomIntegerArray } from './utils'
@@ -13,12 +13,21 @@ const Then = () => {
     localStorage.clear()
     const [theme, setTheme] = useLocalStorage('theme', themes.light)
     const [masterData, setMasterData] = useState({})
+    const toggleTimestamps = useRef<number[]>([])
 
     const toggleTheme = (themeName) => {
         if (themeName === 'konami') {
             setTheme(themes.konami)
         } else {
-            setTheme(theme.name !== 'light' ? themes.light : themes.dark)
+            const now = Date.now()
+            const timestamps = [...toggleTimestamps.current, now].slice(-6)
+            toggleTimestamps.current = timestamps
+            if (timestamps.length === 6 && now - timestamps[0] < 3000) {
+                toggleTimestamps.current = []
+                setTheme(themes.konami)
+            } else {
+                setTheme(theme.name !== 'light' ? themes.light : themes.dark)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Toggling the theme switch 3 times back and forth (6 flips) within 3 seconds activates the Konami theme
- Works on both desktop and mobile — no new UI needed
- Timestamps tracked in a `useRef` so there are no extra re-renders

## Test plan

- [ ] Toggle the switch rapidly 6 times within 3 seconds — Konami theme should activate
- [ ] Toggle slowly (more than 3 seconds for 6 flips) — should just cycle light/dark normally