### PR TITLE
Move About to blog subdomain

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -16,6 +16,7 @@ import r2022 from './assets/2022/right.jpg'
 import r2023 from './assets/2023/left.jpg'
 import l2023 from './assets/2023/right.jpg'
 
+import './prose.css'
 import './About.css'
 
 interface Props {
@@ -115,20 +116,19 @@ const About = (props: Props) => {
     }
 
     return (
-        <div className="Column">
+        <div className="Prose">
             <h1>Confines of Existence</h1>
 
             <p>
                 On the day of my thirtieth birthday, as I wandered through the
                 streets of Havana, I unexpectedly came across the Necropolis of
-                Colon. Armed with a stereoscopic camera crafted from a
-                couple of disposable cameras, I captured images of the exquisite
+                Colon. Armed with a stereoscopic camera crafted from a couple of
+                disposable cameras, I captured images of the exquisite
                 statues.The following year, during a hike in the crater of an
                 inactive volcano situated to the east of my hometown, Mexico
-                City, I found a tomb, this time better prepared with a
-                proper stereoscopic camera. These two moments would lay the
-                foundation of a personal ritual that I would follow in the years
-                to come.
+                City, I found a tomb, this time better prepared with a proper
+                stereoscopic camera. These two moments would lay the foundation
+                of a personal ritual that I would follow in the years to come.
             </p>
             <p>
                 This tradition strengthened my bond with photography as a
@@ -148,13 +148,13 @@ const About = (props: Props) => {
                 enduring passion, acting as a vehicle to recollect intricate
                 details of my own reflection year over year.
             </p>
-            
-            <p className='right noPadding'>
-                <a className='signature' href="https://instagram.com/_amaurs">Amaury Acosta</a>
+
+            <p className="right noPadding">
+                <a className="signature" href="https://instagram.com/_amaurs">
+                    Amaury Acosta
+                </a>
             </p>
-            <p className='right'>
-                San Francisco 2023
-            </p>
+            <p className="right">San Francisco 2023</p>
 
             <div>
                 {info.map((photoProps, i) =>

--- a/src/Blog.tsx
+++ b/src/Blog.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import posts from './posts'
 
+import './index.css'
 import './prose.css'
 
 const Blog = () => {

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -36,8 +36,6 @@ const TravelingSalesman = lazy(
 
 import Then from './Then'
 import Navigation from './Navigation'
-import Blog from './Blog'
-import Post from './Post'
 
 import './Home.css'
 
@@ -563,8 +561,6 @@ const Home = (props) => {
                             )
                         })}
                 </Route>
-                <Route path="/posts" element={<Blog />} />
-                <Route path="/posts/:slug" element={<Post />} />
                 {props.masterData.codes &&
                     props.masterData.codes.map((element, index) => (
                         <Route

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -13,9 +13,6 @@ const Navigation = () => {
                 <Link to="/bits" className="nav-link">
                     <span>Bits</span>
                 </Link>
-                <Link to="/posts" className="nav-link">
-                    <span>Blog</span>
-                </Link>
             </ul>
         </nav>
     )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,15 @@ if (host.length && host[0] === 'blog') {
                                 <Routes>
                                     <Route path="/" element={<Blog />} />
                                     <Route
+                                        path="/posts/Confines-Of-Existence"
+                                        element={
+                                            <About
+                                                title="Confines of Existence"
+                                                url="/posts/Confines-Of-Existence"
+                                            />
+                                        }
+                                    />
+                                    <Route
                                         path="/posts/:slug"
                                         element={<Post />}
                                     />
@@ -75,16 +84,6 @@ if (host.length && host[0] === 'blog') {
         <Router>
             <Suspense fallback={<Spinner />}>
                 <Calendar />
-            </Suspense>
-        </Router>
-    )
-} else if (host.length && host[0] === 'into') {
-    root.render(
-        <Router>
-            <Suspense fallback={<Spinner />}>
-                <div className="Blog">
-                    <About />
-                </div>
             </Suspense>
         </Router>
     )

--- a/src/posts/index.ts
+++ b/src/posts/index.ts
@@ -6,6 +6,7 @@ const posts: { slug: string; url: string }[] = [
     { slug: 'A-Complex-Guide-to-Leaflet-Tiling.md', url: leaflet },
     { slug: 'Hello-Blog.md', url: hello },
     { slug: 'The-Depressive-Bot.md', url: depressiveBot },
+    { slug: 'Confines-Of-Existence', url: '' },
 ]
 
 export default posts


### PR DESCRIPTION
## Summary
- Remove blog from the main app's navigation and routes
- Move the About content to the blog subdomain under \`/posts/Confines-Of-Existence\`
- Fix font loading on the blog subdomain by importing \`index.css\`
- Apply prose styles to the About component

## Test plan
- [ ] Main app: confirm blog link is gone from navigation and \`/blog\` routes no longer resolve
- [ ] Blog subdomain: \`/posts/Confines-Of-Existence\` renders the About content with prose styling
- [ ] Fonts load correctly on the blog subdomain