### PR TITLE
🐛 Fix Konami animation colors clamping to white

### DIFF
--- a/src/bits/colors/Colors.tsx
+++ b/src/bits/colors/Colors.tsx
@@ -1,9 +1,9 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
 import { colorToString, invertColor, colorToGrey } from '../../utils'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
+import { useTimeout } from '../../Hooks'
+import Loader from '../../Presentation'
 import CSS from 'csstype'
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 import './Colors.css'
 
 interface Props {
@@ -47,14 +47,20 @@ const Colors = (props: Props) => {
                     context.save()
                     context.clearRect(0, 0, width, height)
                     if (theme.theme.name === 'konami') {
-                        let grey = colorToGrey(color[0], color[1], color[2])
+                        let luminance = colorToGrey(
+                            color[0],
+                            color[1],
+                            color[2]
+                        )
 
-                        console.log(`grey: ${grey}`)
-
-                        context.fillStyle = colorToString(255, grey, 255)
+                        context.fillStyle = colorToString(255, luminance, 255)
 
                         context.fillRect(0, 0, width, height)
-                        context.fillStyle = colorToString(255, 255 - grey, 255)
+                        context.fillStyle = colorToString(
+                            255,
+                            255 - luminance,
+                            255
+                        )
                         context.fillRect(
                             (width * (1 - Math.sqrt(2) / 2)) / 2,
                             (height * (1 - Math.sqrt(2) / 2)) / 2,

--- a/src/bits/colors/Colors.tsx
+++ b/src/bits/colors/Colors.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
-import { colorToString, invertColor, colorToGrey } from '../../utils'
+import { colorToString, invertColor, colorToGrayscale } from '../../utils'
 import { useTimeout } from '../../Hooks'
 import Loader from '../../Presentation'
 import CSS from 'csstype'
@@ -47,7 +47,7 @@ const Colors = (props: Props) => {
                     context.save()
                     context.clearRect(0, 0, width, height)
                     if (theme.theme.name === 'konami') {
-                        let luminance = colorToGrey(
+                        let luminance = colorToGrayscale(
                             color[0],
                             color[1],
                             color[2]

--- a/src/util/Animation.tsx
+++ b/src/util/Animation.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
-import { colorToInt } from '../utils'
-import { useTimeout } from "../Hooks"
-import Loader from "../Presentation"
-import { ThemeContext } from "../ThemeContext"
+import { colorToInt, colorToGrey } from '../utils'
+import { useTimeout } from '../Hooks'
+import Loader from '../Presentation'
+import { ThemeContext } from '../ThemeContext'
 import './Animation.css'
 
 import CSS from 'csstype'
@@ -86,7 +86,9 @@ const Animation = (props: Props) => {
                 // requestAnimationFrame.
                 timeoutId = setTimeout(function () {
                     const context: CanvasRenderingContext2D =
-                        canvas.current.getContext('2d', { willReadFrequently: true })!
+                        canvas.current.getContext('2d', {
+                            willReadFrequently: true,
+                        })!
                     context.imageSmoothingEnabled = false
                     let canvasWidth = canvas.current.width
                     let canvasHeight = canvas.current.height
@@ -109,8 +111,13 @@ const Animation = (props: Props) => {
                         let j = colorToInt(r, g, b)
 
                         if (theme.theme.name == 'konami') {
+                            let luminance = colorToGrey(
+                                color!.data[i * 4 + 0],
+                                color!.data[i * 4 + 1],
+                                color!.data[i * 4 + 2]
+                            )
                             frame.data[j * 4 + 0] = 255
-                            frame.data[j * 4 + 1] = i * 4
+                            frame.data[j * 4 + 1] = luminance
                             frame.data[j * 4 + 2] = 255
                             frame.data[j * 4 + 3] = 255
                         } else if (theme.theme.name == 'light') {

--- a/src/util/Animation.tsx
+++ b/src/util/Animation.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
-import { colorToInt, colorToGrey } from '../utils'
+import { colorToInt, colorToGrayscale } from '../utils'
 import { useTimeout } from '../Hooks'
 import Loader from '../Presentation'
 import { ThemeContext } from '../ThemeContext'
@@ -111,7 +111,7 @@ const Animation = (props: Props) => {
                         let j = colorToInt(r, g, b)
 
                         if (theme.theme.name == 'konami') {
-                            let luminance = colorToGrey(
+                            let luminance = colorToGrayscale(
                                 color!.data[i * 4 + 0],
                                 color!.data[i * 4 + 1],
                                 color!.data[i * 4 + 2]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,7 @@ export const getBrightness = (
     return (red * 0.3 + green * 0.59 + blue * 0.11) / 255.0
 }
 
-export const colorToGrey = (
+export const colorToGrayscale = (
     red: number,
     green: number,
     blue: number


### PR DESCRIPTION
## Summary

- `Animation.tsx`: green channel was set to `i * 4` in the Konami branch, which overflows `Uint8ClampedArray` (max 255) after just 64 pixels — making the entire animation invisible against the white Konami background. Fixed by using the source color's luminance instead, consistent with the Konami `colorMatrix` and `Colors.tsx`.
- `Colors.tsx`: removed a leftover `console.log` from the same Konami color path.
- `utils.ts`: renamed `colorToGrey` → `colorToGrayscale`; renamed local variable `grey` → `luminance` in callers.

## Test plan

- [ ] Enable Konami theme (Konami code or toggle switch 3× in 3s)
- [ ] Visit the color animation bits — they should now render in magenta shades instead of appearing blank
- [ ] Verify light and dark themes are unaffected