### PR TITLE
Add in-browser MP4 recorder for bits

### DIFF
--- a/docs/decisions/003-in-browser-bit-recorder.md
+++ b/docs/decisions/003-in-browser-bit-recorder.md
@@ -1,0 +1,107 @@
+# ADR 003: In-Browser MP4 Recorder for Bits
+
+**Date**: 2026-05-25
+**Status**: Accepted
+**Branch**: `recorder` (PR #26)
+
+## Context
+
+The bits make good short-form content for Instagram (feed posts and Reels), but there was no path from "running animation in browser" to "MP4 file on phone, ready to post." Doing it the obvious way — recording the screen on a laptop, transferring to phone, posting — adds friction every time and discourages capturing anything.
+
+The recorder needs to:
+
+-   Output Instagram-ready H.264 MP4 (square 1080² or portrait 1080×1920).
+-   Work on phone so recording and posting happen in one flow.
+-   Not bloat the main app bundle or affect anonymous viewers.
+-   Avoid the memory cost of storing hundreds of PNG frames.
+-   Be the only user's tool — owner-gated.
+
+## Options Explored
+
+Four approaches were considered:
+
+### Option A: MediaRecorder Alone
+
+Capture the canvas via `captureStream()`, record with `MediaRecorder`, save the resulting blob.
+
+-   Pros: Zero extra dependencies. Native browser API.
+-   Cons: Most browsers emit WebM, not MP4. iOS Safari does emit MP4/H.264 but other platforms don't. Instagram requires MP4.
+
+### Option B: PNG-per-Frame + Server Encode (the original instinct)
+
+Capture each frame as a PNG, send to a backend that runs FFmpeg.
+
+-   Pros: Maximum control, well-understood pipeline.
+-   Cons: ~300MB of PNGs in memory for a 10s clip at 30fps, network upload, backend infra to maintain. Doesn't work on phone without a round-trip.
+
+### Option C: Playwright + Node FFmpeg (local script)
+
+Local Node script that drives Playwright to load the bit, records via Chrome's headless API, pipes to FFmpeg.
+
+-   Pros: Highest quality, full control.
+-   Cons: Requires a laptop and CLI. Defeats the "record on phone" goal entirely. Would still need to transfer files.
+
+### Option D: MediaRecorder + In-Browser FFmpeg.wasm (selected)
+
+`MediaRecorder` produces a WebM blob (~5–15MB for 10s), `@ffmpeg/ffmpeg` WASM transcodes to MP4 client-side. On iOS Safari, MediaRecorder already emits MP4/H.264, so FFmpeg is skipped entirely.
+
+-   Pros: Works on phone. Small memory footprint. iOS gets a fast path. Bundle stays clean (FFmpeg loaded from CDN at use-time).
+-   Cons: WASM transcode is slower than native (~real-time for `-preset fast`). FFmpeg first-load downloads ~30MB of WASM (cached after).
+
+## Decision
+
+**Option D selected.** Only path that satisfies the phone-first constraint without losing MP4 output.
+
+## Key Sub-Decisions
+
+### Auth: ride Poroto's existing `ProtectedRoute requiredRole="owner"`
+
+The recorder lives at `/record` inside the Poroto subdomain, which already has `GoogleOAuthProvider`, `AuthProvider`, and `ProtectedRoute` configured. No new auth scaffolding.
+
+### Intermediate canvas for letterboxing + WebGL safety
+
+We don't `captureStream()` the bit's canvas directly. Instead, an intermediate 2D canvas at the chosen output dimensions runs a rAF loop that draws the bit canvas into it letterboxed (with theme background filling bars). Two benefits:
+
+1. The bit's native aspect ratio is preserved without crop or stretch.
+2. `drawImage(webglCanvas)` reads pixels synchronously each frame — robust against WebGL contexts that clear between rAF cycles.
+
+We still added `preserveDrawingBuffer: true` to the WebGL bits (Penrose, Corrupted) — separate commits, since those are bit-level concerns, not recorder concerns.
+
+### Single-threaded FFmpeg.wasm
+
+Multi-threaded FFmpeg.wasm requires `SharedArrayBuffer`, which requires `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers. Adding those headers breaks third-party embeds (Google OAuth, Typekit, etc.) and forces a full audit. Single-threaded is slower but avoids the rabbit hole. For 5–30s clips the difference is acceptable.
+
+### FFmpeg loaded from CDN, dynamically imported
+
+`@ffmpeg/ffmpeg` is `import()`-ed inside the transcode function. The WASM core itself is fetched from `https://unpkg.com/@ffmpeg/core@0.12.10` at first use. Zero bytes in the main bundle, nothing downloaded for anonymous viewers, nothing downloaded for owner sessions that don't actually record.
+
+### Bit interface extension via `extraProps`
+
+Most bits accept `{ title, delay, style, width, height }`. The 8 color/animation bits (flood-fill, hilbert, morton, etc.) need `square`, `cube`, `res` for asset paths. Rather than force a uniform interface, the registry entry carries an optional `extraProps` object that the Recorder spreads at render time. Small escape hatch, no refactor.
+
+### Backend-fed bits wrapped, not registered raw
+
+`colors` and `traveling-salesman` need backend data (`/solve` endpoint). The registry can't ship a static prop value, so two thin wrappers in `recorder/backendBits.tsx` fetch the data on mount and pass it through. Bits are not modified.
+
+### Progress bar uses Panama's style and direct DOM ref write
+
+The bottom-of-screen progress bar copies Panama's `scrub`/`scrubFill` styling (3px, faint magenta track, magenta fill). Initial implementation used React state updated each rAF tick — visually it jumped because the rapid setState calls were batched and the DOM lagged. Solved by writing `el.style.width` directly via a ref, bypassing React in the hot path.
+
+### Recording state on the button: disabled, not animated
+
+We briefly tried a pulsing-disc animation on the record button during recording. Reverted to a simple disabled-state opacity dim — consistent with the rest of the chrome and with the project's "no smooth transitions" convention. The bottom progress bar carries all timing feedback.
+
+## Consequences
+
+-   A new owner-gated route at `poroto.<host>/record`.
+-   New dependencies: `@ffmpeg/ffmpeg`, `@ffmpeg/util` (both small npm shims; the heavy WASM is CDN-loaded).
+-   Two Three.js bits now create renderers with `preserveDrawingBuffer: true`. This has a minor performance cost — required for capture.
+-   A new `src/recorder/` directory with the registry, the recording hook, and the backend-fed wrappers. Recorder UI is `src/Recorder.tsx` / `src/Recorder.css`.
+-   The `RecordableBit` interface is the canonical list of "things we want to share on social." When new bits are added, they should be registered here (or explicitly excluded).
+
+## Out of Scope (Future)
+
+-   **Animation speed control.** Each bit owns its own timing primitives (rAF + setTimeout throttles, internal accumulators, Three.js clocks). Adding a uniform `speed` prop requires per-bit changes and was deferred — flagged for a follow-up.
+-   **Audio capture.** Bits don't have audio yet.
+-   **Custom durations beyond 5/10/15/30 seconds.**
+-   **Stories/Reels-specific presets** beyond square and portrait.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
             "name": "home-sweet",
             "version": "0.1.0",
             "dependencies": {
+                "@ffmpeg/ffmpeg": "^0.12.15",
+                "@ffmpeg/util": "^0.12.2",
                 "@react-oauth/google": "^0.13.5",
                 "@tensorflow-models/blazeface": "^0.0.7",
                 "@tensorflow/tfjs": "^3.19.0",
@@ -723,6 +725,36 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@ffmpeg/ffmpeg": {
+            "version": "0.12.15",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz",
+            "integrity": "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==",
+            "license": "MIT",
+            "dependencies": {
+                "@ffmpeg/types": "^0.12.4"
+            },
+            "engines": {
+                "node": ">=18.x"
+            }
+        },
+        "node_modules/@ffmpeg/types": {
+            "version": "0.12.4",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/types/-/types-0.12.4.tgz",
+            "integrity": "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.x"
+            }
+        },
+        "node_modules/@ffmpeg/util": {
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/util/-/util-0.12.2.tgz",
+            "integrity": "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.x"
             }
         },
         "node_modules/@jest/types": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
+        "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/util": "^0.12.2",
         "@react-oauth/google": "^0.13.5",
         "@tensorflow-models/blazeface": "^0.0.7",
         "@tensorflow/tfjs": "^3.19.0",

--- a/src/Poroto.tsx
+++ b/src/Poroto.tsx
@@ -8,8 +8,9 @@ const Names = lazy(() => import('./Names'))
 const Flyer = lazy(() => import('./Flyer'))
 const Days = lazy(() => import('./Days'))
 const Panama = lazy(() => import('./Panama'))
+const Recorder = lazy(() => import('./Recorder'))
 
-const options = ['/names', '/flyer', '/days', '/panama']
+const options = ['/names', '/flyer', '/days', '/panama', '/record']
 const linkTo = (option: string) => option
 
 const PorotoMenu = () => <Menu options={options} linkTo={linkTo} />
@@ -22,6 +23,7 @@ const Poroto = () => (
             <Route path="/flyer" element={<Flyer />} />
             <Route path="/days" element={<Days />} />
             <Route path="/panama/:page?" element={<Panama />} />
+            <Route path="/record" element={<Recorder />} />
         </Routes>
     </Suspense>
 )

--- a/src/Recorder.css
+++ b/src/Recorder.css
@@ -1,0 +1,157 @@
+.Recorder {
+    position: fixed;
+    inset: 0;
+    background: white;
+    color: #161011;
+    font-family: Arial, Helvetica, sans-serif;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.Recorder-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding: 14px 16px;
+    align-items: center;
+    justify-content: center;
+}
+
+.Recorder-bitPicker {
+    font-family: inherit;
+    font-size: 14px;
+    color: #161011;
+    background: transparent;
+    border: none;
+    padding: 4px 18px 4px 0;
+    cursor: pointer;
+    text-transform: lowercase;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, #161011 50%),
+        linear-gradient(135deg, #161011 50%, transparent 50%);
+    background-position: calc(100% - 8px) center, calc(100% - 4px) center;
+    background-size: 4px 4px, 4px 4px;
+    background-repeat: no-repeat;
+}
+
+.Recorder-group {
+    display: flex;
+    gap: 10px;
+}
+
+.Recorder-toggle {
+    font-family: inherit;
+    font-size: 14px;
+    color: #161011;
+    background: transparent;
+    border: none;
+    padding: 4px 2px;
+    cursor: pointer;
+    text-transform: lowercase;
+    opacity: 0.4;
+    letter-spacing: 0.02em;
+}
+
+.Recorder-toggle.active {
+    opacity: 1;
+    border-bottom: 1.5px solid #161011;
+    padding-bottom: 2.5px;
+}
+
+.Recorder-toggle:disabled,
+.Recorder-bitPicker:disabled {
+    opacity: 0.25;
+    cursor: not-allowed;
+}
+
+.Recorder-stage {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    min-height: 0;
+}
+
+.Recorder-frame {
+    box-sizing: content-box;
+    overflow: hidden;
+    border: 1px solid rgba(22, 16, 17, 0.15);
+}
+
+.Recorder-frame-square {
+    aspect-ratio: 1 / 1;
+    width: min(100%, calc(100vh - 220px));
+    height: auto;
+}
+
+.Recorder-frame-portrait {
+    aspect-ratio: 9 / 16;
+    height: min(100%, calc(100vh - 220px));
+    width: auto;
+}
+
+.Recorder-preview {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.Recorder-bitHost {
+    position: absolute;
+    left: -99999px;
+    top: 0;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.Recorder-footer {
+    padding: 16px;
+    display: flex;
+    justify-content: center;
+}
+
+.Recorder-record {
+    font-family: 'LubalinGraphStd-Medium', serif;
+    font-size: 18px;
+    min-width: 140px;
+    height: 56px;
+    border-radius: 28px;
+    border: none;
+    background: magenta;
+    color: white;
+    cursor: pointer;
+    padding: 0 28px 0 22px;
+    text-transform: lowercase;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+}
+
+.Recorder-record:disabled {
+    cursor: not-allowed;
+    background: rgba(255, 0, 255, 0.35);
+}
+
+.Recorder-recordIcon {
+    width: 20px;
+    height: 20px;
+    display: block;
+    flex-shrink: 0;
+}
+
+.Recorder-progress {
+    width: 100%;
+    height: 3px;
+    background: rgba(255, 0, 255, 0.12);
+    flex-shrink: 0;
+}
+
+.Recorder-progressFill {
+    height: 100%;
+    background: magenta;
+    transition: width 0.1s linear;
+}

--- a/src/Recorder.tsx
+++ b/src/Recorder.tsx
@@ -1,0 +1,152 @@
+import React, { useRef, useState, Suspense } from 'react'
+import { recordableBits } from './recorder/bitRegistry'
+import { useRecording } from './recorder/useRecording'
+import './Recorder.css'
+
+const FORMATS = {
+    square: { width: 1080, height: 1080 },
+    portrait: { width: 1080, height: 1920 },
+} as const
+
+const DURATIONS = [5, 10, 15, 30] as const
+
+type Format = keyof typeof FORMATS
+
+const BACKGROUND_COLOR = 'white'
+
+const Recorder = () => {
+    const [bitSlug, setBitSlug] = useState(recordableBits[0].slug)
+    const [format, setFormat] = useState<Format>('square')
+    const [duration, setDuration] = useState<number>(10)
+    const [recordingKey, setRecordingKey] = useState(0)
+
+    const bitContainerRef = useRef<HTMLDivElement>(null)
+    const intermediateRef = useRef<HTMLCanvasElement>(null)
+    const progressFillRef = useRef<HTMLDivElement>(null)
+
+    const { width, height } = FORMATS[format]
+    const bit = recordableBits.find((b) => b.slug === bitSlug)!
+    const BitComponent = bit.Component
+
+    const { status, start } = useRecording({
+        bitContainerRef,
+        intermediateRef,
+        progressFillRef,
+        backgroundColor: BACKGROUND_COLOR,
+        bitSlug,
+        format,
+    })
+
+    const handleRecord = () => {
+        setRecordingKey((k) => k + 1)
+        setTimeout(() => start(duration), 300)
+    }
+
+    const controlsDisabled = status === 'recording' || status === 'encoding'
+
+    return (
+        <div className="Recorder">
+            <div className="Recorder-header">
+                <select
+                    className="Recorder-bitPicker"
+                    value={bitSlug}
+                    onChange={(e) => setBitSlug(e.target.value)}
+                    disabled={controlsDisabled}
+                >
+                    {recordableBits.map((b) => (
+                        <option key={b.slug} value={b.slug}>
+                            {b.name}
+                        </option>
+                    ))}
+                </select>
+                <div className="Recorder-group">
+                    {(Object.keys(FORMATS) as Format[]).map((f) => (
+                        <button
+                            key={f}
+                            className={`Recorder-toggle${
+                                format === f ? ' active' : ''
+                            }`}
+                            onClick={() => setFormat(f)}
+                            disabled={controlsDisabled}
+                        >
+                            {f}
+                        </button>
+                    ))}
+                </div>
+                <div className="Recorder-group">
+                    {DURATIONS.map((d) => (
+                        <button
+                            key={d}
+                            className={`Recorder-toggle${
+                                duration === d ? ' active' : ''
+                            }`}
+                            onClick={() => setDuration(d)}
+                            disabled={controlsDisabled}
+                        >
+                            {d}s
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <div className="Recorder-stage">
+                <div className={`Recorder-frame Recorder-frame-${format}`}>
+                    <canvas
+                        ref={intermediateRef}
+                        width={width}
+                        height={height}
+                        className="Recorder-preview"
+                    />
+                </div>
+            </div>
+
+            <div
+                ref={bitContainerRef}
+                className="Recorder-bitHost"
+                style={{ width, height }}
+            >
+                <Suspense fallback={null}>
+                    <BitComponent
+                        key={`${bitSlug}-${recordingKey}`}
+                        title={bit.name}
+                        delay={0}
+                        style={{}}
+                        width={width}
+                        height={height}
+                        {...(bit.extraProps ?? {})}
+                    />
+                </Suspense>
+            </div>
+
+            <div className="Recorder-footer">
+                <button
+                    className={`Recorder-record Recorder-record-${status}`}
+                    onClick={handleRecord}
+                    disabled={controlsDisabled}
+                >
+                    <svg
+                        className="Recorder-recordIcon"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                    >
+                        <circle
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                        />
+                        <circle cx="12" cy="12" r="6" fill="currentColor" />
+                    </svg>
+                    <span>rec</span>
+                </button>
+            </div>
+            <div className="Recorder-progress">
+                <div ref={progressFillRef} className="Recorder-progressFill" />
+            </div>
+        </div>
+    )
+}
+
+export default Recorder

--- a/src/bits/corrupted/Corrupted.tsx
+++ b/src/bits/corrupted/Corrupted.tsx
@@ -8,11 +8,11 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'
 import { TexturePass } from 'three/examples/jsm/postprocessing/TexturePass.js'
 import './Corrupted.css'
 import escudo from '../../assets/escudo.png'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
+import { useTimeout } from '../../Hooks'
+import Loader from '../../Presentation'
 import { colorMatrixShader } from '../../util/three/shaders'
 
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 import CSS from 'csstype'
 
 interface Props {
@@ -36,6 +36,7 @@ const Corrupted = (props: Props) => {
         if (!presenting) {
             const renderer = new THREE.WebGLRenderer({
                 canvas: canvas.current,
+                preserveDrawingBuffer: true,
             })
             renderer.setPixelRatio(window.devicePixelRatio)
             renderer.setClearColor(0x000000)

--- a/src/bits/penrose/Penrose.tsx
+++ b/src/bits/penrose/Penrose.tsx
@@ -80,6 +80,7 @@ const Penrose = (props: Props) => {
             const renderer = new THREE.WebGLRenderer({
                 canvas: canvas.current,
                 antialias: true,
+                preserveDrawingBuffer: true,
             })
 
             renderer.setPixelRatio(window.devicePixelRatio)

--- a/src/recorder/backendBits.tsx
+++ b/src/recorder/backendBits.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react'
+import Colors from '../bits/colors/Colors'
+import TravelingSalesman from '../bits/travelingsalesman/TravelingSalesman'
+import { getRandomIntegerArray } from '../utils'
+
+const banditHost = import.meta.env.VITE_API_HOST
+
+const NUMBER_COLORS = 500
+const SQUARE_SAMPLING = 100
+
+interface BitProps {
+    title: string
+    delay: number
+    style: React.CSSProperties
+    width: number
+    height: number
+}
+
+export const ColorsBit = (props: BitProps) => {
+    const [colors, setColors] = useState<number[] | null>(null)
+
+    useEffect(() => {
+        let cancel = false
+        const cityPoints = getRandomIntegerArray(NUMBER_COLORS * 3, 0, 256)
+        const url = `${banditHost}/solve?cities=${JSON.stringify(
+            cityPoints
+        )}&dimension=3`
+        fetch(url)
+            .then((r) => r.json())
+            .then((json) => {
+                if (!cancel) setColors(json)
+            })
+            .catch((e) => console.log('colors fetch failed', e))
+        return () => {
+            cancel = true
+        }
+    }, [])
+
+    if (!colors) return null
+    return <Colors {...props} colors={colors} />
+}
+
+export const TravelingSalesmanBit = (props: BitProps) => {
+    const [cities, setCities] = useState<{
+        cities: number[]
+        hasFetched: boolean
+    } | null>(null)
+
+    useEffect(() => {
+        let cancel = false
+        const cityPoints = getRandomIntegerArray(
+            NUMBER_COLORS * 2,
+            1,
+            SQUARE_SAMPLING
+        )
+        const url = `${banditHost}/solve?cities=${JSON.stringify(
+            cityPoints
+        )}&dimension=2`
+        fetch(url)
+            .then((r) => r.json())
+            .then((json) => {
+                if (!cancel) setCities({ cities: json, hasFetched: true })
+            })
+            .catch((e) => console.log('traveling salesman fetch failed', e))
+        return () => {
+            cancel = true
+        }
+    }, [])
+
+    if (!cities) return null
+    return (
+        <TravelingSalesman
+            {...props}
+            cities={cities}
+            numberColors={NUMBER_COLORS}
+            squareSampling={SQUARE_SAMPLING}
+        />
+    )
+}

--- a/src/recorder/bitRegistry.ts
+++ b/src/recorder/bitRegistry.ts
@@ -1,0 +1,119 @@
+import { lazy, LazyExoticComponent, ComponentType } from 'react'
+
+export interface BitProps {
+    title: string
+    delay: number
+    style: React.CSSProperties
+    width: number
+    height: number
+}
+
+export interface RecordableBit {
+    slug: string
+    name: string
+    Component: LazyExoticComponent<ComponentType<any>>
+    extraProps?: Record<string, unknown>
+}
+
+const animationBit = (slug: string, res: string): RecordableBit => ({
+    slug,
+    name: slug,
+    Component: lazy(() => import('../util/Animation')),
+    extraProps: {
+        res,
+        square: `/colors/${slug}/${res}/square.png`,
+        cube: `/colors/${slug}/${res}/cube.png`,
+    },
+})
+
+export const recordableBits: RecordableBit[] = [
+    {
+        slug: 'conway',
+        name: 'conway',
+        Component: lazy(() => import('../bits/conway/Conway')),
+    },
+    {
+        slug: 'voronoi',
+        name: 'voronoi',
+        Component: lazy(() => import('../bits/voronoi/Voronoi')),
+    },
+    {
+        slug: 'mandelbrot',
+        name: 'mandelbrot',
+        Component: lazy(() => import('../bits/mandelbrot/Mandelbrot')),
+    },
+    {
+        slug: 'loom',
+        name: 'loom',
+        Component: lazy(() => import('../bits/loom/Loom')),
+    },
+    {
+        slug: 'quilt',
+        name: 'quilt',
+        Component: lazy(() => import('../bits/quilt/Quilt')),
+    },
+    {
+        slug: 'anaglyph',
+        name: 'anaglyph',
+        Component: lazy(() => import('../bits/anaglyph/Anaglyph')),
+    },
+    {
+        slug: 'stereo',
+        name: 'stereo',
+        Component: lazy(() => import('../bits/stereo/Stereo')),
+    },
+    {
+        slug: 'autostereogram',
+        name: 'autostereogram',
+        Component: lazy(() => import('../bits/autostereogram/Autostereogram')),
+    },
+    {
+        slug: 'nostalgia',
+        name: 'nostalgia',
+        Component: lazy(() => import('../bits/nostalgia/Nostalgia')),
+    },
+    {
+        slug: '1986',
+        name: '1986',
+        Component: lazy(() => import('../bits/distrito/Distrito')),
+    },
+    {
+        slug: 'gridworld',
+        name: 'gridworld',
+        Component: lazy(() => import('../bits/reinforcement/Reinforcement')),
+    },
+    {
+        slug: 'penrose',
+        name: 'penrose',
+        Component: lazy(() => import('../bits/penrose/Penrose')),
+    },
+    {
+        slug: 'corrupted',
+        name: 'corrupted',
+        Component: lazy(() => import('../bits/corrupted/Corrupted')),
+    },
+    animationBit('flood-fill', '64'),
+    animationBit('hamiltonian-cycle', '512'),
+    animationBit('hilbert', '512'),
+    animationBit('identity', '512'),
+    animationBit('morton', '512'),
+    animationBit('quadtree', '512'),
+    animationBit('random', '512'),
+    animationBit('simulated-annealing', '512'),
+    {
+        slug: 'colors',
+        name: 'colors',
+        Component: lazy(() =>
+            import('./backendBits').then((m) => ({ default: m.ColorsBit }))
+        ),
+    },
+    {
+        slug: 'traveling-salesman',
+        name: 'traveling salesman',
+        Component: lazy(() =>
+            import('./backendBits').then((m) => ({
+                default: m.TravelingSalesmanBit,
+            }))
+        ),
+    },
+]

--- a/src/recorder/useRecording.ts
+++ b/src/recorder/useRecording.ts
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useRef, useState, RefObject } from 'react'
+
+export type RecordingStatus = 'idle' | 'recording' | 'encoding' | 'done'
+
+interface UseRecordingOptions {
+    bitContainerRef: RefObject<HTMLDivElement>
+    intermediateRef: RefObject<HTMLCanvasElement>
+    progressFillRef: RefObject<HTMLDivElement>
+    backgroundColor: string
+    bitSlug: string
+    format: 'square' | 'portrait'
+}
+
+const MP4_TYPES = [
+    'video/mp4;codecs=avc1.42E01E',
+    'video/mp4;codecs=h264',
+    'video/mp4',
+]
+
+const WEBM_TYPES = [
+    'video/webm;codecs=vp9',
+    'video/webm;codecs=vp8',
+    'video/webm',
+]
+
+const pickMimeType = (): string => {
+    for (const t of [...MP4_TYPES, ...WEBM_TYPES]) {
+        if (MediaRecorder.isTypeSupported(t)) return t
+    }
+    return ''
+}
+
+const triggerDownload = (blob: Blob, filename: string) => {
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+let ffmpegInstance: any = null
+let ffmpegLoading: Promise<any> | null = null
+
+const getFFmpeg = async () => {
+    if (ffmpegInstance) return ffmpegInstance
+    if (ffmpegLoading) return ffmpegLoading
+    ffmpegLoading = (async () => {
+        const { FFmpeg } = await import('@ffmpeg/ffmpeg')
+        const { toBlobURL } = await import('@ffmpeg/util')
+        const ffmpeg = new FFmpeg()
+        const baseURL = 'https://unpkg.com/@ffmpeg/core@0.12.10/dist/umd'
+        await ffmpeg.load({
+            coreURL: await toBlobURL(
+                `${baseURL}/ffmpeg-core.js`,
+                'text/javascript'
+            ),
+            wasmURL: await toBlobURL(
+                `${baseURL}/ffmpeg-core.wasm`,
+                'application/wasm'
+            ),
+        })
+        ffmpegInstance = ffmpeg
+        return ffmpeg
+    })()
+    return ffmpegLoading
+}
+
+const transcodeToMp4 = async (input: Blob, ext: string): Promise<Blob> => {
+    const { fetchFile } = await import('@ffmpeg/util')
+    const ffmpeg = await getFFmpeg()
+    const inputName = `input.${ext}`
+    await ffmpeg.writeFile(inputName, await fetchFile(input))
+    await ffmpeg.exec([
+        '-i',
+        inputName,
+        '-c:v',
+        'libx264',
+        '-preset',
+        'fast',
+        '-crf',
+        '20',
+        '-pix_fmt',
+        'yuv420p',
+        '-movflags',
+        '+faststart',
+        'output.mp4',
+    ])
+    const data = await ffmpeg.readFile('output.mp4')
+    return new Blob([data], { type: 'video/mp4' })
+}
+
+const drawLetterboxed = (
+    target: HTMLCanvasElement,
+    source: HTMLCanvasElement,
+    background: string
+) => {
+    const ctx = target.getContext('2d')
+    if (!ctx) return
+    ctx.fillStyle = background
+    ctx.fillRect(0, 0, target.width, target.height)
+    if (source.width === 0 || source.height === 0) return
+    const sourceAspect = source.width / source.height
+    const targetAspect = target.width / target.height
+    let dw: number, dh: number, dx: number, dy: number
+    if (sourceAspect > targetAspect) {
+        dw = target.width
+        dh = target.width / sourceAspect
+        dx = 0
+        dy = (target.height - dh) / 2
+    } else {
+        dh = target.height
+        dw = target.height * sourceAspect
+        dx = (target.width - dw) / 2
+        dy = 0
+    }
+    ctx.drawImage(source, dx, dy, dw, dh)
+}
+
+export const useRecording = ({
+    bitContainerRef,
+    intermediateRef,
+    progressFillRef,
+    backgroundColor,
+    bitSlug,
+    format,
+}: UseRecordingOptions) => {
+    const [status, setStatus] = useState<RecordingStatus>('idle')
+    const backgroundRef = useRef(backgroundColor)
+
+    const setProgressWidth = (p: number) => {
+        const el = progressFillRef.current
+        if (el) el.style.width = `${p * 100}%`
+    }
+
+    useEffect(() => {
+        backgroundRef.current = backgroundColor
+    }, [backgroundColor])
+
+    useEffect(() => {
+        let frameId: number | null = null
+        const draw = () => {
+            const target = intermediateRef.current
+            const source = bitContainerRef.current?.querySelector('canvas')
+            if (target && source instanceof HTMLCanvasElement) {
+                drawLetterboxed(target, source, backgroundRef.current)
+            }
+            frameId = requestAnimationFrame(draw)
+        }
+        frameId = requestAnimationFrame(draw)
+        return () => {
+            if (frameId !== null) cancelAnimationFrame(frameId)
+        }
+    }, [bitContainerRef, intermediateRef])
+
+    const start = useCallback(
+        (durationSeconds: number) => {
+            const target = intermediateRef.current
+            if (!target) return
+            const mimeType = pickMimeType()
+            if (!mimeType) {
+                console.error('No supported MediaRecorder mime type')
+                return
+            }
+            const stream = target.captureStream(30)
+            const chunks: Blob[] = []
+            let recorder: MediaRecorder
+            try {
+                recorder = new MediaRecorder(stream, {
+                    mimeType,
+                    videoBitsPerSecond: 8_000_000,
+                })
+            } catch (e) {
+                console.error('MediaRecorder failed', e)
+                return
+            }
+            recorder.ondataavailable = (e) => {
+                if (e.data && e.data.size > 0) chunks.push(e.data)
+            }
+            recorder.onstop = async () => {
+                const blob = new Blob(chunks, { type: mimeType })
+                const isMp4 = mimeType.startsWith('video/mp4')
+                const stamp = new Date()
+                    .toISOString()
+                    .replace(/[:.]/g, '-')
+                    .slice(0, 19)
+                const baseName = `${bitSlug}-${format}-${stamp}`
+                if (isMp4) {
+                    triggerDownload(blob, `${baseName}.mp4`)
+                    setStatus('idle')
+                    setProgressWidth(0)
+                    return
+                }
+                setStatus('encoding')
+                try {
+                    const ext = mimeType.includes('webm') ? 'webm' : 'bin'
+                    const mp4 = await transcodeToMp4(blob, ext)
+                    triggerDownload(mp4, `${baseName}.mp4`)
+                    setStatus('idle')
+                    setProgressWidth(0)
+                } catch (e) {
+                    console.error('Transcode failed', e)
+                    setStatus('idle')
+                    setProgressWidth(0)
+                }
+            }
+            recorder.start()
+            setStatus('recording')
+            setProgressWidth(0)
+            const startedAt = performance.now()
+            const durationMs = durationSeconds * 1000
+            let stopped = false
+            const tick = () => {
+                if (stopped) return
+                const elapsed = performance.now() - startedAt
+                const p = Math.min(1, elapsed / durationMs)
+                setProgressWidth(p)
+                if (p >= 1) {
+                    stopped = true
+                    if (recorder.state !== 'inactive') recorder.stop()
+                    return
+                }
+                requestAnimationFrame(tick)
+            }
+            requestAnimationFrame(tick)
+        },
+        [intermediateRef, progressFillRef, bitSlug, format]
+    )
+
+    return { status, start }
+}


### PR DESCRIPTION
## Summary

- New owner-only `/record` route under Poroto that captures any registered bit as an Instagram-ready MP4 (square 1080² or portrait 1080×1920).
- Designed to run on phone so recording and posting happen in one flow.
- Pipeline: MediaRecorder captures an intermediate canvas that letterboxes the bit's native aspect. iOS Safari returns native H.264 MP4; elsewhere we transcode via `@ffmpeg/ffmpeg` loaded from CDN at use-time, so the main bundle stays untouched for anonymous viewers.
- 23 bits registered: standard canvas bits, the 8 color/animation bits, and the two backend-fed ones (`colors`, `traveling-salesman`) which fetch once on mount.
- `preserveDrawingBuffer: true` added to the two Three.js bits (Penrose, Corrupted) so the WebGL canvas can be captured.

## Test plan

- [ ] Hit `poroto.<host>/record` — owner-gated screen renders.
- [ ] Pick each bit, confirm preview animates in the frame.
- [ ] Toggle square ↔ portrait — frame and letterboxing update.
- [ ] Record a 2D bit (e.g. conway) — MP4 downloads, plays correctly.
- [ ] Record a WebGL bit (penrose) — output has actual 3D content, no black frames.
- [ ] Record a color/animation bit (hilbert) — backend assets render, MP4 downloads.
- [ ] iOS Safari: confirm MP4 downloads natively (no FFmpeg load).
- [ ] Anonymous user: redirected away from `/record`.
- [ ] Main app bundle size unchanged for `/` (FFmpeg only loads when recording on non-iOS).