### PR TITLE
♻️ Extract useAnimationLoop hook from per-bit setTimeout+rAF pattern

### DIFF
--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -44,6 +44,33 @@ export function useRequestAnimationFrame(animateCallback) {
     }, [animateCallback])
 }
 
+// Frame-aligned animation loop capped at `fps`. Pass fps=null to pause.
+export function useAnimationLoop(fps, callback) {
+    const savedCallback = useRef(callback)
+
+    useEffect(() => {
+        savedCallback.current = callback
+    }, [callback])
+
+    useEffect(() => {
+        if (fps == null) return
+        const interval = 1000 / fps
+        let frameId = null
+        let timeoutId = null
+        const tick = () => {
+            timeoutId = setTimeout(() => {
+                savedCallback.current()
+                frameId = requestAnimationFrame(tick)
+            }, interval)
+        }
+        frameId = requestAnimationFrame(tick)
+        return () => {
+            if (frameId != null) cancelAnimationFrame(frameId)
+            if (timeoutId != null) clearTimeout(timeoutId)
+        }
+    }, [fps])
+}
+
 export function useTimeout(callback, delay) {
     const savedCallback = useRef()
     const timeoutRef = useRef()

--- a/src/bits/anaglyph/Anaglyph.tsx
+++ b/src/bits/anaglyph/Anaglyph.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useContext } from 'react'
 import * as THREE from 'three'
 import AnaglyphSVGRenderer from './AnaglyphSVGRenderer.js'
+import { useAnimationLoop } from '../../Hooks'
 import './Anaglyph.css'
 import { ThemeContext } from '../../ThemeContext'
 
@@ -16,6 +17,7 @@ const Anaglyph = (props: Props) => {
     const div = useRef<HTMLDivElement>(document.createElement('div'))
     const theme = useContext(ThemeContext)
 
+    const tickRef = useRef(() => {})
     useEffect(() => {
         if (props.width <= 0 || props.height <= 0) return
 
@@ -55,29 +57,24 @@ const Anaglyph = (props: Props) => {
         const line = new THREE.LineSegments(edges, material)
         scene.add(line)
 
-        let frameId: number
-        let timeoutId: any
-
-        const animate = () => {
-            timeoutId = setTimeout(() => {
-                line.rotation.x += 0.01
-                line.rotation.y += 0.01
-                renderer.render(scene, camera)
-                frameId = requestAnimationFrame(animate)
-            }, 1000 / 60)
+        tickRef.current = () => {
+            line.rotation.x += 0.01
+            line.rotation.y += 0.01
+            renderer.render(scene, camera)
         }
 
-        frameId = requestAnimationFrame(animate)
-
         return () => {
-            cancelAnimationFrame(frameId)
-            clearTimeout(timeoutId)
+            tickRef.current = () => {}
             scene.remove(line)
             edges.dispose()
             curve.dispose()
             material.dispose()
         }
     }, [props.width, props.height, theme])
+
+    useAnimationLoop(props.width > 0 && props.height > 0 ? 60 : null, () =>
+        tickRef.current()
+    )
 
     return <div className="Anaglyph" style={{ ...props.style }} ref={div}></div>
 }

--- a/src/bits/autostereogram/Autostereogram.tsx
+++ b/src/bits/autostereogram/Autostereogram.tsx
@@ -1,11 +1,11 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
 import * as THREE from 'three'
-import Board from "../../Board"
+import Board from '../../Board'
 import './Autostereogram.css'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
+import Loader from '../../Presentation'
 import CSS from 'csstype'
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 
 interface Props {
     title: string
@@ -34,113 +34,95 @@ const Autostereogram = (props: Props) => {
         setShow(!show)
     }
 
+    const tickRef = useRef(() => {})
     useEffect(() => {
-        if (props.width > 0 && props.height > 0 && !presenting) {
-            let canvas = document.createElement('canvas')
-            let width = autostereogramCanvas.current.clientWidth
-            let height = autostereogramCanvas.current.clientHeight
-            const scene = new THREE.Scene()
-            const camera = new THREE.PerspectiveCamera(
-                75,
-                width / height,
-                1,
-                1000
-            )
-            const renderer = new THREE.WebGLRenderer({
-                canvas: canvas,
-                antialias: true,
-            })
-            const geometry = new THREE.BoxGeometry(2.5, 2.5, 2.5)
-            const material = new THREE.MeshDepthMaterial({ wireframe: false })
-            const cube = new THREE.Mesh(geometry, material)
-            const needResize =
-                canvas.width !== width || canvas.height !== height
-            if (needResize) {
-                renderer.setSize(width, height, false)
-            }
-            camera.position.z = 4
-            scene.add(cube)
-            renderer.setClearColor('#000000')
-            renderer.setSize(width, height)
+        if (!(props.width > 0 && props.height > 0 && !presenting)) return
+        let canvas = document.createElement('canvas')
+        let width = autostereogramCanvas.current.clientWidth
+        let height = autostereogramCanvas.current.clientHeight
+        const scene = new THREE.Scene()
+        const camera = new THREE.PerspectiveCamera(75, width / height, 1, 1000)
+        const renderer = new THREE.WebGLRenderer({
+            canvas: canvas,
+            antialias: true,
+        })
+        const geometry = new THREE.BoxGeometry(2.5, 2.5, 2.5)
+        const material = new THREE.MeshDepthMaterial({ wireframe: false })
+        const cube = new THREE.Mesh(geometry, material)
+        const needResize = canvas.width !== width || canvas.height !== height
+        if (needResize) {
+            renderer.setSize(width, height, false)
+        }
+        camera.position.z = 4
+        scene.add(cube)
+        renderer.setClearColor('#000000')
+        renderer.setSize(width, height)
 
-            const renderScene = () => {
-                renderer.render(scene, camera)
-                const virtualCanvas = renderer.domElement
-                let realCanvas = autostereogramCanvas.current!
-                let realContext = realCanvas.getContext('2d')!
-                realContext.clearRect(0, 0, width, height)
-                realContext.drawImage(virtualCanvas, 0, 0, width, height)
-                if (show) {
-                    let frame = realContext.getImageData(0, 0, width, height)
+        const renderScene = () => {
+            renderer.render(scene, camera)
+            const virtualCanvas = renderer.domElement
+            let realCanvas = autostereogramCanvas.current!
+            let realContext = realCanvas.getContext('2d')!
+            realContext.clearRect(0, 0, width, height)
+            realContext.drawImage(virtualCanvas, 0, 0, width, height)
+            if (show) {
+                let frame = realContext.getImageData(0, 0, width, height)
+                let strip_width = Math.round(width / AUTOSTEREOGRAM_STRIPS)
+                let board = new Board(strip_width, height)
+                board.init()
+                board.randomize()
+                let color = theme.theme.name === 'konami' ? 255 : 0
 
-                    let strip_width = Math.round(width / AUTOSTEREOGRAM_STRIPS)
-
-                    let board = new Board(strip_width, height)
-                    board.init()
-                    board.randomize()
-
-                    let color = theme.theme.name === 'konami' ? 255 : 0
-
-                    for (let y = 0; y < frame.height; y++) {
-                        for (let x = 0; x < frame.width; x++) {
-                            let index = (y * frame.width + x) * 4
-                            if (!(x < strip_width)) {
-                                let average =
-                                    (frame.data[index + 0] +
-                                        frame.data[index + 1] +
-                                        frame.data[index + 2]) /
-                                    3 /
-                                    255
-                                let offset = Math.floor(average * (64 - 1))
-                                if (offset > 0) {
-                                    board.setXY(
-                                        x % strip_width,
-                                        y,
-                                        board.getXY(
-                                            (x % strip_width) + offset,
-                                            y
-                                        )
-                                    )
-                                }
-                            }
-                            if (board.getXY(x % strip_width, y)) {
-                                frame.data[index + 0] = color
-                                frame.data[index + 1] = 0
-                                frame.data[index + 2] = color
-                            } else {
-                                frame.data[index + 0] = 255
-                                frame.data[index + 1] = 255
-                                frame.data[index + 2] = 255
+                for (let y = 0; y < frame.height; y++) {
+                    for (let x = 0; x < frame.width; x++) {
+                        let index = (y * frame.width + x) * 4
+                        if (!(x < strip_width)) {
+                            let average =
+                                (frame.data[index + 0] +
+                                    frame.data[index + 1] +
+                                    frame.data[index + 2]) /
+                                3 /
+                                255
+                            let offset = Math.floor(average * (64 - 1))
+                            if (offset > 0) {
+                                board.setXY(
+                                    x % strip_width,
+                                    y,
+                                    board.getXY((x % strip_width) + offset, y)
+                                )
                             }
                         }
+                        if (board.getXY(x % strip_width, y)) {
+                            frame.data[index + 0] = color
+                            frame.data[index + 1] = 0
+                            frame.data[index + 2] = color
+                        } else {
+                            frame.data[index + 0] = 255
+                            frame.data[index + 1] = 255
+                            frame.data[index + 2] = 255
+                        }
                     }
-                    realContext.putImageData(frame, 0, 0)
                 }
-            }
-
-            let timeoutId: any
-
-            const animate = () => {
-                timeoutId = setTimeout(function () {
-                    cube.rotation.x += 0.04
-                    cube.rotation.y += 0.04
-                    renderScene()
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 10)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-
-            return () => {
-                cancelAnimationFrame(frameId!)
-                clearTimeout(timeoutId)
-                frameId = null
-                scene.remove(cube)
-                geometry.dispose()
-                material.dispose()
+                realContext.putImageData(frame, 0, 0)
             }
         }
+
+        tickRef.current = () => {
+            cube.rotation.x += 0.04
+            cube.rotation.y += 0.04
+            renderScene()
+        }
+
+        return () => {
+            tickRef.current = () => {}
+            scene.remove(cube)
+            geometry.dispose()
+            material.dispose()
+        }
     }, [show, props.width, props.height, presenting, theme])
+
+    const autoRunning = props.width > 0 && props.height > 0 && !presenting
+    useAnimationLoop(autoRunning ? 10 : null, () => tickRef.current())
 
     let style = {}
 

--- a/src/bits/bolero/Bolero.tsx
+++ b/src/bits/bolero/Bolero.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState, useRef, useContext } from 'react'
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 import './Bolero.css'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
+import Loader from '../../Presentation'
 import CSS from 'csstype'
 
 interface Props {
@@ -25,29 +25,17 @@ export default function Bolero(props: Props) {
         setDelay(100)
     }, props.delay)
 
+    const nRef = useRef(0)
     useEffect(() => {
-        if (props.sentence.length > 0 && !presenting) {
-            let n = 0
-            let timeoutId: any
-
-            const animate = () => {
-                timeoutId = setTimeout(function () {
-                    console.log(props.sentence.slice(0, n))
-                    div.current.innerHTML = props.sentence.slice(0, n)
-                    n += 1
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 5)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
-            }
-        }
+        nRef.current = 0
     }, [props.sentence, presenting])
+
+    const boleroRunning = props.sentence.length > 0 && !presenting
+    useAnimationLoop(boleroRunning ? 5 : null, () => {
+        console.log(props.sentence.slice(0, nRef.current))
+        div.current.innerHTML = props.sentence.slice(0, nRef.current)
+        nRef.current += 1
+    })
 
     let style: CSS.Properties = {
         color: theme.theme.middleground,

--- a/src/bits/colors/Colors.tsx
+++ b/src/bits/colors/Colors.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
 import { colorToString, invertColor, colorToGrayscale } from '../../utils'
-import { useTimeout } from '../../Hooks'
+import { useTimeout, useAnimationLoop } from '../../Hooks'
 import Loader from '../../Presentation'
 import CSS from 'csstype'
 import { ThemeContext } from '../../ThemeContext'
@@ -24,83 +24,51 @@ const Colors = (props: Props) => {
         setPresenting(false)
     }, props.delay)
 
+    const nRef = useRef(0)
     useEffect(() => {
-        if (props.colors.length > 0 && !presenting) {
-            let n = 0
-            let timeoutId: any
-
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    let color = [
-                        props.colors[(n % (props.colors.length / 3)) * 3],
-                        props.colors[(n % (props.colors.length / 3)) * 3 + 1],
-                        props.colors[(n % (props.colors.length / 3)) * 3 + 2],
-                    ]
-
-                    const context: CanvasRenderingContext2D =
-                        canvas.current.getContext('2d')!
-                    const width = canvas.current.width
-                    const height = canvas.current.height
-                    context.save()
-                    context.clearRect(0, 0, width, height)
-                    if (theme.theme.name === 'konami') {
-                        let luminance = colorToGrayscale(
-                            color[0],
-                            color[1],
-                            color[2]
-                        )
-
-                        context.fillStyle = colorToString(255, luminance, 255)
-
-                        context.fillRect(0, 0, width, height)
-                        context.fillStyle = colorToString(
-                            255,
-                            255 - luminance,
-                            255
-                        )
-                        context.fillRect(
-                            (width * (1 - Math.sqrt(2) / 2)) / 2,
-                            (height * (1 - Math.sqrt(2) / 2)) / 2,
-                            width / Math.sqrt(2),
-                            height / Math.sqrt(2)
-                        )
-                    } else {
-                        context.fillStyle = colorToString(
-                            color[0],
-                            color[1],
-                            color[2]
-                        )
-                        context.fillRect(0, 0, width, height)
-                        context.fillStyle = invertColor(
-                            color[0],
-                            color[1],
-                            color[2]
-                        )
-                        context.fillRect(
-                            (width * (1 - Math.sqrt(2) / 2)) / 2,
-                            (height * (1 - Math.sqrt(2) / 2)) / 2,
-                            width / Math.sqrt(2),
-                            height / Math.sqrt(2)
-                        )
-                    }
-
-                    n += 1
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 10)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
-            }
-        }
+        nRef.current = 0
     }, [props.colors, presenting, theme])
+
+    const colorsRunning = props.colors.length > 0 && !presenting
+    useAnimationLoop(colorsRunning ? 10 : null, () => {
+        const n = nRef.current
+        let color = [
+            props.colors[(n % (props.colors.length / 3)) * 3],
+            props.colors[(n % (props.colors.length / 3)) * 3 + 1],
+            props.colors[(n % (props.colors.length / 3)) * 3 + 2],
+        ]
+
+        const context: CanvasRenderingContext2D =
+            canvas.current.getContext('2d')!
+        const width = canvas.current.width
+        const height = canvas.current.height
+        context.save()
+        context.clearRect(0, 0, width, height)
+        if (theme.theme.name === 'konami') {
+            let luminance = colorToGrayscale(color[0], color[1], color[2])
+            context.fillStyle = colorToString(255, luminance, 255)
+            context.fillRect(0, 0, width, height)
+            context.fillStyle = colorToString(255, 255 - luminance, 255)
+            context.fillRect(
+                (width * (1 - Math.sqrt(2) / 2)) / 2,
+                (height * (1 - Math.sqrt(2) / 2)) / 2,
+                width / Math.sqrt(2),
+                height / Math.sqrt(2)
+            )
+        } else {
+            context.fillStyle = colorToString(color[0], color[1], color[2])
+            context.fillRect(0, 0, width, height)
+            context.fillStyle = invertColor(color[0], color[1], color[2])
+            context.fillRect(
+                (width * (1 - Math.sqrt(2) / 2)) / 2,
+                (height * (1 - Math.sqrt(2) / 2)) / 2,
+                width / Math.sqrt(2),
+                height / Math.sqrt(2)
+            )
+        }
+
+        nRef.current += 1
+    })
 
     let style = {}
 

--- a/src/bits/conway/Conway.tsx
+++ b/src/bits/conway/Conway.tsx
@@ -5,13 +5,13 @@ import React, {
     useContext,
     useEffect,
 } from 'react'
-import { useInterval, useTimeout } from "../../Hooks"
+import { useAnimationLoop, useTimeout } from '../../Hooks'
 import { colorMatrix } from '../../utils'
-import Board from "../../Board"
+import Board from '../../Board'
 import './Conway.css'
-import Loader from "../../Presentation"
+import Loader from '../../Presentation'
 
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 import CSS from 'csstype'
 
 interface Props {
@@ -45,48 +45,18 @@ const Conway = (props: Props) => {
         setPresenting(false)
     }, props.delay)
 
-    useEffect(() => {
-        if (!presenting) {
-            let timeoutId: any
-
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    board = board.getNextGeneration()
-                    let canvas = ref.current
-                    const context: CanvasRenderingContext2D =
-                        canvas.getContext('2d')!
-
-                    context.clearRect(0, 0, canvas.width, canvas.height)
-                    //context.fillStyle = theme.theme.foreground;
-                    //let color = board.getColor(context, squareSize, position[0] / squareSize,
-                    //                                     position[1] / squareSize,
-                    //                                     square[0] / squareSize,
-                    //                                     square[1] / squareSize);
-                    let colorProcessed = colorMatrix(
-                        baseColor,
-                        theme.theme.colorMatrix
-                    )
-                    board.printContext(
-                        context,
-                        squareSize,
-                        `rgba(${colorProcessed[0]}, ${colorProcessed[1]}, ${colorProcessed[2]}, ${colorProcessed[3]})`
-                    )
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 60)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
-            }
-        }
-    }, [presenting, theme])
+    useAnimationLoop(presenting ? null : 60, () => {
+        board = board.getNextGeneration()
+        let canvas = ref.current
+        const context: CanvasRenderingContext2D = canvas.getContext('2d')!
+        context.clearRect(0, 0, canvas.width, canvas.height)
+        let colorProcessed = colorMatrix(baseColor, theme.theme.colorMatrix)
+        board.printContext(
+            context,
+            squareSize,
+            `rgba(${colorProcessed[0]}, ${colorProcessed[1]}, ${colorProcessed[2]}, ${colorProcessed[3]})`
+        )
+    })
 
     const handleOnMouseDown = (e: MouseEvent) => {
         let rect = ref.current.getBoundingClientRect()

--- a/src/bits/corrupted/Corrupted.tsx
+++ b/src/bits/corrupted/Corrupted.tsx
@@ -8,7 +8,7 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'
 import { TexturePass } from 'three/examples/jsm/postprocessing/TexturePass.js'
 import './Corrupted.css'
 import escudo from '../../assets/escudo.png'
-import { useTimeout } from '../../Hooks'
+import { useTimeout, useAnimationLoop } from '../../Hooks'
 import Loader from '../../Presentation'
 import { colorMatrixShader } from '../../util/three/shaders'
 
@@ -32,71 +32,59 @@ const Corrupted = (props: Props) => {
         setPresenting(false)
     }, props.delay)
 
+    const tickRef = useRef(() => {})
     useEffect(() => {
-        if (!presenting) {
-            const renderer = new THREE.WebGLRenderer({
-                canvas: canvas.current,
-                preserveDrawingBuffer: true,
-            })
-            renderer.setPixelRatio(window.devicePixelRatio)
-            renderer.setClearColor(0x000000)
+        if (presenting) return
+        const renderer = new THREE.WebGLRenderer({
+            canvas: canvas.current,
+            preserveDrawingBuffer: true,
+        })
+        renderer.setPixelRatio(window.devicePixelRatio)
+        renderer.setClearColor(0x000000)
 
-            const glitchPass = new GlitchPass()
-            glitchPass.goWild = false
-            const magentaPass = new ShaderPass(
-                colorMatrixShader(theme.theme.colorMatrix)
-            )
+        const glitchPass = new GlitchPass()
+        glitchPass.goWild = false
+        const magentaPass = new ShaderPass(
+            colorMatrixShader(theme.theme.colorMatrix)
+        )
 
-            const copyPass = new ShaderPass(CopyShader)
-            copyPass.renderToScreen = true
-            const parameters = {
-                minFilter: THREE.LinearFilter,
-                magFilter: THREE.LinearFilter,
-                format: THREE.RGBAFormat,
-                stencilBuffer: true,
-            }
+        const copyPass = new ShaderPass(CopyShader)
+        copyPass.renderToScreen = true
+        const parameters = {
+            minFilter: THREE.LinearFilter,
+            magFilter: THREE.LinearFilter,
+            format: THREE.RGBAFormat,
+            stencilBuffer: true,
+        }
 
-            let renderTarget
+        renderer.setSize(props.width, props.width)
+        const renderTarget = new THREE.WebGLRenderTarget(
+            props.width,
+            props.width,
+            parameters
+        )
 
-            renderer.setSize(props.width, props.width)
-            renderTarget = new THREE.WebGLRenderTarget(
-                props.width,
-                props.width,
-                parameters
-            )
+        const composer = new EffectComposer(renderer, renderTarget)
 
-            const composer = new EffectComposer(renderer, renderTarget)
+        const texture = new THREE.TextureLoader().load(escudo)
 
-            const texture = new THREE.TextureLoader().load(escudo)
+        const texturePass = new TexturePass(texture)
 
-            const texturePass = new TexturePass(texture)
+        composer.addPass(texturePass)
+        composer.addPass(glitchPass)
+        composer.addPass(glitchPass)
+        composer.addPass(magentaPass)
+        composer.addPass(copyPass)
 
-            composer.addPass(texturePass)
-            composer.addPass(glitchPass)
-            composer.addPass(glitchPass)
-            composer.addPass(magentaPass)
-            composer.addPass(copyPass)
-
-            let timeoutId: any
-
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    composer.render()
-                    frameId = requestAnimationFrame(animate)
-                }, 0)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-
-            return () => {
-                cancelAnimationFrame(frameId!)
-                frameId = null
-            }
+        tickRef.current = () => {
+            composer.render()
+        }
+        return () => {
+            tickRef.current = () => {}
         }
     }, [props.width, props.height, presenting, theme])
+
+    useAnimationLoop(presenting ? null : 60, () => tickRef.current())
 
     let style = {}
 

--- a/src/bits/distrito/Distrito.tsx
+++ b/src/bits/distrito/Distrito.tsx
@@ -9,12 +9,12 @@ import channelsFirst from '../../assets/first-channels-small.png'
 import channelsSecond from '../../assets/second-channels-small.png'
 import channelsThird from '../../assets/third-channels-small.png'
 import channelMask from '../../assets/mask-small.png'
-import { useTimeout } from "../../Hooks"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
 import { colorImageData, getRandomInt } from '../../utils'
-import Loader from "../../Presentation"
+import Loader from '../../Presentation'
 import './Distrito.css'
 import CSS from 'csstype'
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 
 interface Props {
     title: string
@@ -189,108 +189,80 @@ const Distrito = (props: Props) => {
         })
     }, [])
 
-    useEffect(() => {
-        if (multiImage !== undefined && !presenting) {
-            let timeoutId: any
+    const distritoRunning = multiImage !== undefined && !presenting
+    useAnimationLoop(distritoRunning ? 6 : null, () => {
+        const realContext: CanvasRenderingContext2D =
+            mount.current.getContext('2d')!
+        let canvasWidth = mount.current.width
+        let canvasHeight = mount.current.height
+        realContext.clearRect(0, 0, canvasWidth, canvasHeight)
+        realContext.filter =
+            'brightness(1) saturate(100%) contrast(100%) opacity(1)'
 
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    const realContext: CanvasRenderingContext2D =
-                        mount.current.getContext('2d')!
-                    let canvasWidth = mount.current.width
-                    let canvasHeight = mount.current.height
-                    realContext.clearRect(0, 0, canvasWidth, canvasHeight)
-                    realContext.filter =
-                        'brightness(1) saturate(100%) contrast(100%) opacity(1)'
+        const offscreen: HTMLCanvasElement = document.createElement('canvas')
+        offscreen.width = mount.current.width
+        offscreen.height = mount.current.height
 
-                    const offscreen: HTMLCanvasElement =
-                        document.createElement('canvas')
-                    offscreen.width = mount.current.width
-                    offscreen.height = mount.current.height
+        let context: CanvasRenderingContext2D = offscreen.getContext('2d')!
+        context.clearRect(0, 0, canvasWidth, canvasHeight)
 
-                    let context: CanvasRenderingContext2D =
-                        offscreen.getContext('2d')!
-                    context.clearRect(0, 0, canvasWidth, canvasHeight)
-
-                    multiImage!.channels.forEach(
-                        (channel: Uint8ClampedArray, index: number) => {
-                            context.putImageData(
-                                colorImageData(
-                                    multiImage!.getGrayImageData(index),
-                                    theme.theme.colorMatrix
-                                ),
-                                index * multiImage!.width,
-                                0
-                            )
-                        }
-                    )
-
-                    let mapRows: Array<Array<Map>> = []
-
-                    for (let i = 0; i < 2; i++) {
-                        let row: Array<Map> = []
-                        let positions = selectRandomFrom(
-                            [0, 1, 2, 3, 4, 5, 6],
-                            3
-                        )
-                        console.log(positions)
-                        let colors = selectRandomFrom(
-                            [Color.RED, Color.GREEN, Color.BLUE],
-                            3
-                        )
-                        for (let j = 0; j < 3; j++) {
-                            row.push({
-                                position: positions[j],
-                                color: colors[j],
-                            })
-                        }
-                        mapRows.push(row)
-                    }
-
-                    mapRows!.forEach((mapRow: Array<Map>, index: number) => {
-                        let mergedBands = [-1, -1, -1]
-
-                        mapRow.forEach((map: Map) => {
-                            let bands = [-1, -1, -1]
-                            bands[map.color] = map.position
-                            mergedBands[map.color] = map.position
-                            context.putImageData(
-                                colorImageData(
-                                    multiImage!.getMixImageData(bands),
-                                    theme.theme.colorMatrix
-                                ),
-                                map.position * multiImage!.width,
-                                (1 + index) * multiImage!.height
-                            )
-                        })
-
-                        context.putImageData(
-                            colorImageData(
-                                multiImage!.getMixImageData(mergedBands),
-                                theme.theme.colorMatrix
-                            ),
-                            multiImage!.channels.length * multiImage!.width,
-                            (1 + index) * multiImage!.height
-                        )
-                    })
-                    realContext.drawImage(offscreen, 0, 0)
-
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 6)
+        multiImage!.channels.forEach(
+            (channel: Uint8ClampedArray, index: number) => {
+                context.putImageData(
+                    colorImageData(
+                        multiImage!.getGrayImageData(index),
+                        theme.theme.colorMatrix
+                    ),
+                    index * multiImage!.width,
+                    0
+                )
             }
+        )
 
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
+        let mapRows: Array<Array<Map>> = []
+
+        for (let i = 0; i < 2; i++) {
+            let row: Array<Map> = []
+            let positions = selectRandomFrom([0, 1, 2, 3, 4, 5, 6], 3)
+            console.log(positions)
+            let colors = selectRandomFrom(
+                [Color.RED, Color.GREEN, Color.BLUE],
+                3
+            )
+            for (let j = 0; j < 3; j++) {
+                row.push({ position: positions[j], color: colors[j] })
             }
+            mapRows.push(row)
         }
-    }, [multiImage, presenting, theme])
+
+        mapRows!.forEach((mapRow: Array<Map>, index: number) => {
+            let mergedBands = [-1, -1, -1]
+
+            mapRow.forEach((map: Map) => {
+                let bands = [-1, -1, -1]
+                bands[map.color] = map.position
+                mergedBands[map.color] = map.position
+                context.putImageData(
+                    colorImageData(
+                        multiImage!.getMixImageData(bands),
+                        theme.theme.colorMatrix
+                    ),
+                    map.position * multiImage!.width,
+                    (1 + index) * multiImage!.height
+                )
+            })
+
+            context.putImageData(
+                colorImageData(
+                    multiImage!.getMixImageData(mergedBands),
+                    theme.theme.colorMatrix
+                ),
+                multiImage!.channels.length * multiImage!.width,
+                (1 + index) * multiImage!.height
+            )
+        })
+        realContext.drawImage(offscreen, 0, 0)
+    })
 
     let style = { width: props.width + 'px' }
 

--- a/src/bits/julia/Julia.tsx
+++ b/src/bits/julia/Julia.tsx
@@ -8,11 +8,11 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'
 import { TexturePass } from 'three/examples/jsm/postprocessing/TexturePass.js'
 import './Julia.css'
 import escudo from '../../assets/escudo.png'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
+import Loader from '../../Presentation'
 import { colorMatrixShader } from '../../util/three/shaders'
 
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 import CSS from 'csstype'
 
 interface Props {
@@ -32,70 +32,58 @@ const Julia = (props: Props) => {
         setPresenting(false)
     }, props.delay)
 
+    const tickRef = useRef(() => {})
     useEffect(() => {
-        if (!presenting) {
-            const renderer = new THREE.WebGLRenderer({
-                canvas: canvas.current,
-            })
-            renderer.setPixelRatio(window.devicePixelRatio)
-            renderer.setClearColor(0x000000)
+        if (presenting) return
+        const renderer = new THREE.WebGLRenderer({
+            canvas: canvas.current,
+        })
+        renderer.setPixelRatio(window.devicePixelRatio)
+        renderer.setClearColor(0x000000)
 
-            const glitchPass = new GlitchPass()
-            glitchPass.goWild = false
-            const magentaPass = new ShaderPass(
-                colorMatrixShader(theme.theme.colorMatrix)
-            )
+        const glitchPass = new GlitchPass()
+        glitchPass.goWild = false
+        const magentaPass = new ShaderPass(
+            colorMatrixShader(theme.theme.colorMatrix)
+        )
 
-            const copyPass = new ShaderPass(CopyShader)
-            copyPass.renderToScreen = true
-            const parameters = {
-                minFilter: THREE.LinearFilter,
-                magFilter: THREE.LinearFilter,
-                format: THREE.RGBAFormat,
-                stencilBuffer: true,
-            }
+        const copyPass = new ShaderPass(CopyShader)
+        copyPass.renderToScreen = true
+        const parameters = {
+            minFilter: THREE.LinearFilter,
+            magFilter: THREE.LinearFilter,
+            format: THREE.RGBAFormat,
+            stencilBuffer: true,
+        }
 
-            let renderTarget
+        renderer.setSize(props.width, props.width)
+        const renderTarget = new THREE.WebGLRenderTarget(
+            props.width,
+            props.width,
+            parameters
+        )
 
-            renderer.setSize(props.width, props.width)
-            renderTarget = new THREE.WebGLRenderTarget(
-                props.width,
-                props.width,
-                parameters
-            )
+        const composer = new EffectComposer(renderer, renderTarget)
 
-            const composer = new EffectComposer(renderer, renderTarget)
+        const texture = new THREE.TextureLoader().load(escudo)
 
-            const texture = new THREE.TextureLoader().load(escudo)
+        const texturePass = new TexturePass(texture)
 
-            const texturePass = new TexturePass(texture)
+        composer.addPass(texturePass)
+        composer.addPass(glitchPass)
+        composer.addPass(glitchPass)
+        composer.addPass(magentaPass)
+        composer.addPass(copyPass)
 
-            composer.addPass(texturePass)
-            composer.addPass(glitchPass)
-            composer.addPass(glitchPass)
-            composer.addPass(magentaPass)
-            composer.addPass(copyPass)
-
-            let timeoutId: any
-
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    composer.render()
-                    frameId = requestAnimationFrame(animate)
-                }, 0)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-
-            return () => {
-                cancelAnimationFrame(frameId!)
-                frameId = null
-            }
+        tickRef.current = () => {
+            composer.render()
+        }
+        return () => {
+            tickRef.current = () => {}
         }
     }, [props.width, props.height, presenting, theme])
+
+    useAnimationLoop(presenting ? null : 60, () => tickRef.current())
 
     let style = {}
 

--- a/src/bits/loom/Loom.tsx
+++ b/src/bits/loom/Loom.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useContext, useEffect } from 'react'
 import ColorBoard from '../../ColorBoard'
+import { useAnimationLoop } from '../../Hooks'
 import './Loom.css'
 import CSS from 'csstype'
 import { ThemeContext } from '../../ThemeContext'
@@ -165,8 +166,8 @@ const Loom = (props: Props) => {
     let canvas = useRef<HTMLCanvasElement>(document.createElement('canvas'))
     const theme = useContext(ThemeContext)
 
+    const tickRef = useRef(() => {})
     useEffect(() => {
-        let timeoutId: any
         let step = 0
         const cycleEvery = 100
 
@@ -273,88 +274,73 @@ const Loom = (props: Props) => {
 
         let currentPat = randomCombo()
 
-        const animate = () => {
-            timeoutId = setTimeout(function () {
-                const context = canvas.current.getContext('2d')!
-                context.clearRect(
-                    0,
-                    0,
-                    canvas.current.width,
-                    canvas.current.height
+        tickRef.current = () => {
+            const context = canvas.current.getContext('2d')!
+            context.clearRect(0, 0, canvas.current.width, canvas.current.height)
+
+            if (step > 0 && step % cycleEvery === 0) {
+                currentPat = randomCombo()
+            }
+
+            const pat = currentPat
+            const gridSize = canvasSize / squareSize
+            const weaveWidth = gridSize - pat.treadles
+            const weaveHeight = gridSize - pat.shafts
+
+            const shiftedPat = {
+                ...pat,
+                threading: pat.threading.map(
+                    (s) => (s + Math.floor(step / 5)) % pat.shafts
+                ),
+                treadling: pat.treadling.map(
+                    (t) => (t + Math.floor(step / 3)) % pat.treadles
+                ),
+            }
+
+            if (Math.random() < 0.1) {
+                const idx = Math.floor(
+                    Math.random() * shiftedPat.threading.length
                 )
-
-                if (step > 0 && step % cycleEvery === 0) {
-                    currentPat = randomCombo()
-                }
-
-                const pat = currentPat
-                const gridSize = canvasSize / squareSize
-                const weaveWidth = gridSize - pat.treadles
-                const weaveHeight = gridSize - pat.shafts
-
-                const shiftedPat = {
-                    ...pat,
-                    threading: pat.threading.map(
-                        (s) => (s + Math.floor(step / 5)) % pat.shafts
-                    ),
-                    treadling: pat.treadling.map(
-                        (t) => (t + Math.floor(step / 3)) % pat.treadles
-                    ),
-                }
-
-                if (Math.random() < 0.1) {
-                    const idx = Math.floor(
-                        Math.random() * shiftedPat.threading.length
-                    )
-                    shiftedPat.threading[idx] = Math.floor(
-                        Math.random() * pat.shafts
-                    )
-                }
-
-                const threading = buildThreading(
-                    shiftedPat,
-                    weaveWidth,
-                    warpColors
+                shiftedPat.threading[idx] = Math.floor(
+                    Math.random() * pat.shafts
                 )
-                const treadling = buildTreadling(
-                    shiftedPat,
-                    weaveHeight,
-                    weftColors
-                )
-                const tieup = buildTieup(pat, tieupColor)
+            }
 
-                const weave = treadling
-                    .multiply(tieup.transpose())
-                    .multiply(threading)
+            const threading = buildThreading(shiftedPat, weaveWidth, warpColors)
+            const treadling = buildTreadling(
+                shiftedPat,
+                weaveHeight,
+                weftColors
+            )
+            const tieup = buildTieup(pat, tieupColor)
 
-                threading.printContextOffset(context, squareSize, 0, 0)
-                treadling.printContextOffset(
-                    context,
-                    squareSize,
-                    gridSize - pat.treadles,
-                    pat.shafts
-                )
-                tieup.printContextOffset(
-                    context,
-                    squareSize,
-                    gridSize - pat.treadles,
-                    0
-                )
-                weave.printContextOffset(context, squareSize, 0, pat.shafts)
+            const weave = treadling
+                .multiply(tieup.transpose())
+                .multiply(threading)
 
-                step++
+            threading.printContextOffset(context, squareSize, 0, 0)
+            treadling.printContextOffset(
+                context,
+                squareSize,
+                gridSize - pat.treadles,
+                pat.shafts
+            )
+            tieup.printContextOffset(
+                context,
+                squareSize,
+                gridSize - pat.treadles,
+                0
+            )
+            weave.printContextOffset(context, squareSize, 0, pat.shafts)
 
-                frameId = requestAnimationFrame(animate)
-            }, 1000 / 10)
+            step++
         }
-
-        let frameId: number | null = requestAnimationFrame(animate)
         return () => {
-            cancelAnimationFrame(frameId!)
-            clearTimeout(timeoutId)
-            frameId = null
+            tickRef.current = () => {}
         }
     }, [theme])
+
+    useAnimationLoop(10, () => tickRef.current())
 
     let style = {}
     if (props.width > 0 && props.height > 0) {

--- a/src/bits/mandelbrot/Mandelbrot.tsx
+++ b/src/bits/mandelbrot/Mandelbrot.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useRef, useContext, useEffect } from 'react'
-import { useTimeout } from "../../Hooks"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
 import './Mandelbrot.css'
-import Loader from "../../Presentation"
+import Loader from '../../Presentation'
 import myMandelbrot from '../../assets/mandelbrot-small.png'
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 
 import CSS from 'csstype'
 
@@ -144,79 +144,52 @@ const Mandelbrot = (props: Props) => {
         }
     }, [props.width, props.height, presenting])
 
+    const tickRef = useRef(0)
     useEffect(() => {
-        if (imageData !== undefined) {
-            let tick = 0
-            let timeoutId: any
-
-            // TODO: Move this declaration to the Theme file when that is ported to typescript.
-
-            if (theme.theme.name === 'light') {
-                colors = wikipedia
-            } else if (theme.theme.name === 'dark') {
-                colors = apple
-            } else if (theme.theme.name === 'konami') {
-                colors = magentaToWhite
-            }
-
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    let canvas = mount.current
-
-                    canvas.width = imageData!.width
-                    canvas.height = imageData!.height
-                    const context2: CanvasRenderingContext2D =
-                        mount.current.getContext('2d')!
-                    let frame = context2.createImageData(imageData!)
-                    for (
-                        let i = 0;
-                        i < imageData!.width * imageData!.height * 4;
-                        i += 4
-                    ) {
-                        let n = imageData!.data[i]
-
-                        // This should not be a constant, this value is the module
-                        // of the complex number after it just escaped to infinity.
-
-                        let module = Math.sqrt(5)
-                        let logAbs = Math.log(module)
-                        let logTwo = Math.log(2.0)
-                        let aux = Math.log(logAbs) / logTwo
-                        let continuous = 1.0 + n * 1.0 - aux
-                        let index = Math.floor(continuous)
-                        let a: Array<number> | undefined = colors.get(
-                            (index + tick) % colors.size
-                        )
-                        let b: Array<number> | undefined = colors.get(
-                            (index + 1 + tick) % colors.size
-                        )
-                        let p = 1 - (continuous - index)
-                        let red = Math.floor(p * a![0] + (1 - p) * b![0])
-                        let green = Math.floor(p * a![1] + (1 - p) * b![1])
-                        let blue = Math.floor(p * a![2] + (1 - p) * b![2])
-                        frame.data[i] = red
-                        frame.data[i + 1] = green
-                        frame.data[i + 2] = blue
-                        frame.data[i + 3] = 255
-                    }
-                    context2.putImageData(frame, 0, 0)
-                    tick = tick + 1
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 8)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
-            }
-        }
+        tickRef.current = 0
     }, [imageData, theme])
+
+    useAnimationLoop(imageData !== undefined ? 8 : null, () => {
+        if (theme.theme.name === 'light') {
+            colors = wikipedia
+        } else if (theme.theme.name === 'dark') {
+            colors = apple
+        } else if (theme.theme.name === 'konami') {
+            colors = magentaToWhite
+        }
+
+        let canvas = mount.current
+        canvas.width = imageData!.width
+        canvas.height = imageData!.height
+        const context2: CanvasRenderingContext2D =
+            mount.current.getContext('2d')!
+        let frame = context2.createImageData(imageData!)
+        for (let i = 0; i < imageData!.width * imageData!.height * 4; i += 4) {
+            let n = imageData!.data[i]
+            let module = Math.sqrt(5)
+            let logAbs = Math.log(module)
+            let logTwo = Math.log(2.0)
+            let aux = Math.log(logAbs) / logTwo
+            let continuous = 1.0 + n * 1.0 - aux
+            let index = Math.floor(continuous)
+            let a: Array<number> | undefined = colors.get(
+                (index + tickRef.current) % colors.size
+            )
+            let b: Array<number> | undefined = colors.get(
+                (index + 1 + tickRef.current) % colors.size
+            )
+            let p = 1 - (continuous - index)
+            let red = Math.floor(p * a![0] + (1 - p) * b![0])
+            let green = Math.floor(p * a![1] + (1 - p) * b![1])
+            let blue = Math.floor(p * a![2] + (1 - p) * b![2])
+            frame.data[i] = red
+            frame.data[i + 1] = green
+            frame.data[i + 2] = blue
+            frame.data[i + 3] = 255
+        }
+        context2.putImageData(frame, 0, 0)
+        tickRef.current += 1
+    })
 
     let style = {}
     if (props.width > 0 && props.height > 0) {

--- a/src/bits/penrose/Penrose.tsx
+++ b/src/bits/penrose/Penrose.tsx
@@ -4,7 +4,7 @@ import { CopyShader } from 'three/examples/jsm/shaders/CopyShader.js'
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js'
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js'
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'
-import { useTimeout } from '../../Hooks'
+import { useTimeout, useAnimationLoop } from '../../Hooks'
 import Loader from '../../Presentation'
 import { ThemeContext } from '../../ThemeContext'
 import { colorMatrixShader } from '../../util/three/shaders'
@@ -30,106 +30,89 @@ const Penrose = (props: Props) => {
         setPresenting(false)
     }, props.delay)
 
+    const tickRef = useRef(() => {})
     useEffect(() => {
-        if (props.width > 0 && props.height > 0 && !presenting) {
-            let width, height
-            if (props.width < props.height) {
-                width = props.width
-                height = props.width
-            } else {
-                width = props.height
-                height = props.height
+        if (!(props.width > 0 && props.height > 0 && !presenting)) return
+        let width, height
+        if (props.width < props.height) {
+            width = props.width
+            height = props.width
+        } else {
+            width = props.height
+            height = props.height
+        }
+
+        const material = new THREE.MeshPhongMaterial({
+            vertexColors: true,
+            side: THREE.DoubleSide,
+        })
+
+        let geometries: Array<PenroseBufferGeometry> = [4, 5, 6, 7].map(
+            (i) => new PenroseBufferGeometry(200, i)
+        )
+
+        const scene = new THREE.Scene()
+
+        const light = new THREE.DirectionalLight(0xffffff, 1)
+        light.position.set(0, 0, -10)
+        scene.add(light)
+
+        const camera = new THREE.PerspectiveCamera(70, width / height, 1, 1000)
+        camera.position.z = 100
+
+        let objects = geometries.map((geometry, i) => {
+            let mesh = new THREE.Mesh(geometry, material)
+            if (i > 0) {
+                mesh.visible = false
             }
+            scene.add(mesh)
+            return mesh
+        })
 
-            const material = new THREE.MeshPhongMaterial({
-                vertexColors: true,
-                side: THREE.DoubleSide,
+        const renderer = new THREE.WebGLRenderer({
+            canvas: canvas.current,
+            antialias: true,
+            preserveDrawingBuffer: true,
+        })
+
+        renderer.setPixelRatio(window.devicePixelRatio)
+        renderer.setSize(width, height)
+        renderer.setClearColor(0xffffff, 0.0)
+
+        const colorPass = new ShaderPass(
+            colorMatrixShader(theme.theme.colorMatrix)
+        )
+        const copyPass = new ShaderPass(CopyShader)
+        copyPass.renderToScreen = true
+
+        const composer = new EffectComposer(renderer)
+        composer.addPass(new RenderPass(scene, camera))
+        composer.addPass(colorPass)
+        composer.addPass(copyPass)
+
+        let i = 0
+        tickRef.current = () => {
+            objects.forEach((object, index) => {
+                object.visible = index == Math.floor(i / 24) % objects.length
+                object.rotation.z -= 0.01
             })
+            composer.render()
+            i++
+        }
 
-            let geometries: Array<PenroseBufferGeometry> = [4, 5, 6, 7].map(
-                (i) => {
-                    return new PenroseBufferGeometry(200, i)
-                }
-            )
-
-            const scene = new THREE.Scene()
-
-            const color = 0xffffff
-            const intensity = 1
-            const light = new THREE.DirectionalLight(color, intensity)
-            light.position.set(0, 0, -10)
-            scene.add(light)
-
-            const camera = new THREE.PerspectiveCamera(
-                70,
-                width / height,
-                1,
-                1000
-            )
-            camera.position.z = 100
-
-            let objects = geometries.map((geometry, i) => {
-                let mesh = new THREE.Mesh(geometry, material)
-                if (i > 0) {
-                    mesh.visible = false
-                }
-                scene.add(mesh)
-                return mesh
-            })
-
-            const renderer = new THREE.WebGLRenderer({
-                canvas: canvas.current,
-                antialias: true,
-                preserveDrawingBuffer: true,
-            })
-
-            renderer.setPixelRatio(window.devicePixelRatio)
-            renderer.setSize(width, height)
-            renderer.setClearColor(0xffffff, 0.0)
-
-            const colorPass = new ShaderPass(
-                colorMatrixShader(theme.theme.colorMatrix)
-            )
-            const copyPass = new ShaderPass(CopyShader)
-            copyPass.renderToScreen = true
-
-            const composer = new EffectComposer(renderer)
-            composer.addPass(new RenderPass(scene, camera))
-            composer.addPass(colorPass)
-            composer.addPass(copyPass)
-
-            let timeoutId: any
-            let i: number = 0
-
-            const animate = () => {
-                timeoutId = setTimeout(function () {
-                    objects.forEach((object, index) => {
-                        object.visible =
-                            index == Math.floor(i / 24) % objects.length
-                        object.rotation.z -= 0.01
-                    })
-                    composer.render()
-                    frameId = requestAnimationFrame(animate)
-                    i++
-                }, 1000 / 40)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                frameId = null
-                clearTimeout(timeoutId)
-                objects.forEach((mesh) => {
-                    scene.remove(mesh)
-                })
-                geometries.forEach((geometry) => {
-                    geometry.dispose()
-                })
-                material.dispose()
-                renderer.dispose()
-            }
+        return () => {
+            tickRef.current = () => {}
+            objects.forEach((mesh) => scene.remove(mesh))
+            geometries.forEach((geometry) => geometry.dispose())
+            material.dispose()
+            renderer.dispose()
         }
     }, [data, props.width, props.height, presenting, theme])
+
+    useAnimationLoop(
+        props.width > 0 && props.height > 0 && !presenting ? 40 : null,
+        () => tickRef.current()
+    )
 
     if (presenting) {
         return <Loader title={props.title} />

--- a/src/bits/quilt/Quilt.tsx
+++ b/src/bits/quilt/Quilt.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
-import { useTimeout } from "../../Hooks"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
 
 import { shuffle } from '../../utils'
 import { getRandomInt } from '../../utils'
 
-import Loader from "../../Presentation"
+import Loader from '../../Presentation'
 import CSS from 'csstype'
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 import './Quilt.css'
 
 const squareSize = 500
@@ -82,78 +82,59 @@ const Quilt: React.FC<Props> = (props: Props) => {
         setPresenting(false)
     }, props.delay)
 
-    useEffect(() => {
-        if (!presenting && canvas && canvas.current) {
-            let timeoutId: any
+    useAnimationLoop(presenting ? null : 5, () => {
+        const context: CanvasRenderingContext2D =
+            canvas.current.getContext('2d')!
+        const width = canvas.current.width
+        const height = canvas.current.height
 
-            const animate = () => {
-                timeoutId = setTimeout(function () {
-                    const context: CanvasRenderingContext2D =
-                        canvas.current.getContext('2d')!
-                    const width = canvas.current.width
-                    const height = canvas.current.height
+        context.fillStyle = theme.quilt[3]
+        context.fillRect(0, 0, width, height)
 
-                    context.fillStyle = theme.quilt[3]
-                    context.fillRect(0, 0, width, height)
+        let allObjects = shuffle([
+            o1,
+            o1,
+            o1,
+            o1,
+            o1,
+            o1,
+            o2,
+            o2,
+            o2,
+            o2,
+            o2,
+            o2,
+            o3,
+            o3,
+            o3,
+            o3,
+            o4,
+            o4,
+            o4,
+            o4,
+        ])
 
-                    let allObjects = shuffle([
-                        o1,
-                        o1,
-                        o1,
-                        o1,
-                        o1,
-                        o1,
-                        o2,
-                        o2,
-                        o2,
-                        o2,
-                        o2,
-                        o2,
-                        o3,
-                        o3,
-                        o3,
-                        o3,
-                        o4,
-                        o4,
-                        o4,
-                        o4,
-                    ])
+        for (let j = 0; j < 4; j++) {
+            for (let i = 0; i < 5; i++) {
+                const o = allObjects[5 * j + i]
+                context.fillStyle = o.color
+                context.beginPath()
+                context.translate(
+                    i * (squareSize * 2) + squareSize,
+                    j * (squareSize * 2) + squareSize
+                )
+                context.rotate((getRandomInt(0, 4) * Math.PI) / 2)
+                context.moveTo(o.points[0][0], o.points[0][1])
 
-                    for (let j = 0; j < 4; j++) {
-                        for (let i = 0; i < 5; i++) {
-                            const o = allObjects[5 * j + i]
-                            context.fillStyle = o.color
-                            context.beginPath()
-                            context.translate(
-                                i * (squareSize * 2) + squareSize,
-                                j * (squareSize * 2) + squareSize
-                            )
-                            context.rotate((getRandomInt(0, 4) * Math.PI) / 2)
-                            context.moveTo(o.points[0][0], o.points[0][1])
+                for (let k = 1; k < o.points.length; k++) {
+                    context.lineTo(o.points[k][0], o.points[k][1])
+                }
 
-                            for (let k = 1; k < o.points.length; k++) {
-                                context.lineTo(o.points[k][0], o.points[k][1])
-                            }
-
-                            context.resetTransform()
-                            context.fill()
-                        }
-                    }
-
-                    allObjects.forEach((o: Patch) => {})
-
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 5)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                clearTimeout(timeoutId)
-                frameId = null
+                context.resetTransform()
+                context.fill()
             }
         }
-    }, [presenting, theme])
+    })
 
     let style = {}
 

--- a/src/bits/reinforcement/Reinforcement.tsx
+++ b/src/bits/reinforcement/Reinforcement.tsx
@@ -3,10 +3,10 @@ import { Environment, map } from '../../rl/windyGridworld.js'
 import Controller from '../../rl/controller'
 import { Agent } from '../../rl/sarsaAgent.js'
 import './Reinforcement.css'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
+import Loader from '../../Presentation'
 
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 
 import CSS from 'csstype'
 
@@ -61,33 +61,16 @@ export default function Reinforcement(props: Props) {
     }
 
     const [board, setBoard] = useState(controller.toBoard())
-    const requestRef = useRef<number | undefined>()
     const [presenting, setPresenting] = useState(props.delay > 0)
 
     useTimeout(() => {
         setPresenting(false)
     }, props.delay)
 
-    useEffect(() => {
-        let timeoutId: any
-        let n = 0
-        if (!presenting && board !== null) {
-            const animate = () => {
-                timeoutId = setTimeout(function () {
-                    controller.tick()
-                    setBoard(controller.toBoard())
-                    n += 1
-                    requestRef.current = requestAnimationFrame(animate)
-                }, 1000 / 24)
-            }
-            requestRef.current = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(requestRef.current!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-            }
-        }
-    }, [presenting, board])
+    useAnimationLoop(!presenting && board !== null ? 24 : null, () => {
+        controller.tick()
+        setBoard(controller.toBoard())
+    })
 
     if (presenting) {
         return <Loader title={props.title} />

--- a/src/bits/stereo/Stereo.tsx
+++ b/src/bits/stereo/Stereo.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect, useRef, useContext } from 'react'
 import './Stereo.css'
-import Loader from "../../Presentation"
-import { useTimeout } from "../../Hooks"
+import Loader from '../../Presentation'
+import { useTimeout, useAnimationLoop } from '../../Hooks'
 import { getRandomInt, colorImageData } from '../../utils'
 
 import left from '../../assets/2019/left.jpg'
 import right from '../../assets/2019/right.jpg'
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 
 import CSS from 'csstype'
 
@@ -82,42 +82,21 @@ const Stereo = (props: Props) => {
         }
     }, [theme])
 
+    const tickRef = useRef(0)
     useEffect(() => {
-        if (frames !== undefined && !presenting) {
-            // This constants come from the execution of the image,
-            // need to figure out how to pass this down in a more
-            // dynamic way.
-
-            let tick = 0
-
-            let timeoutId: any
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    let canvas = mount.current
-
-                    canvas.width = frames[0].width
-                    canvas.height = frames[0].height
-                    const context: CanvasRenderingContext2D =
-                        mount.current.getContext('2d')!
-                    context.putImageData(frames[tick % frames.length], 0, 0)
-                    tick = tick + 1
-
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 8)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
-            }
-        }
+        tickRef.current = 0
     }, [frames, presenting])
+
+    const stereoRunning = frames !== undefined && !presenting
+    useAnimationLoop(stereoRunning ? 8 : null, () => {
+        let canvas = mount.current
+        canvas.width = frames![0].width
+        canvas.height = frames![0].height
+        const context: CanvasRenderingContext2D =
+            mount.current.getContext('2d')!
+        context.putImageData(frames![tickRef.current % frames!.length], 0, 0)
+        tickRef.current += 1
+    })
 
     let style = {}
     if (props.width > 0 && props.height > 0) {

--- a/src/bits/travelingsalesman/TravelingSalesman.tsx
+++ b/src/bits/travelingsalesman/TravelingSalesman.tsx
@@ -1,9 +1,9 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
+import Loader from '../../Presentation'
 import './TravelingSalesman.css'
 
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 
 import CSS from 'csstype'
 
@@ -30,75 +30,9 @@ const TravelingSalesman = (props: Props) => {
         setPresenting(false)
     }, props.delay)
 
+    const nRef = useRef(0)
     useEffect(() => {
-        if (props.cities.cities.length > 0 && !presenting) {
-            let n = 0
-            let timeoutId: any
-
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    const maxBound = (time: number, size: number) => {
-                        let t = time % (2 * size)
-                        if (t < size) {
-                            return t
-                        } else {
-                            return size
-                        }
-                    }
-                    const minBound = (time: number, size: number) => {
-                        let t = time % (2 * size)
-                        if (t < size) {
-                            return 0
-                        } else {
-                            return time % size
-                        }
-                    }
-                    let min = minBound(n, props.numberColors + 1)
-                    let max = maxBound(n, props.numberColors + 1)
-                    let citiesToDraw = props.cities.cities.slice(
-                        min * 2,
-                        max * 2
-                    )
-
-                    const context: CanvasRenderingContext2D =
-                        canvas.current.getContext('2d')!
-                    const width = canvas.current.width
-                    const height = canvas.current.height
-                    context.save()
-                    context.clearRect(0, 0, width, height)
-                    context.fillStyle = theme.theme.background
-                    context.fillRect(0, 0, width, height)
-                    context.beginPath()
-                    context.strokeStyle = theme.theme.middleground
-                    context.lineWidth = 5
-                    for (let i = 0; i < citiesToDraw.length; i += 2) {
-                        context.lineTo(
-                            Math.floor(
-                                (width * citiesToDraw[i]) / props.squareSampling
-                            ),
-                            Math.floor(
-                                (height * citiesToDraw[i + 1]) /
-                                    props.squareSampling
-                            )
-                        )
-                    }
-                    context.stroke()
-                    n += 1
-                    frameId = requestAnimationFrame(animate)
-                }, 1000 / 60)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
-            }
-        }
+        nRef.current = 0
     }, [
         props.cities,
         props.squareSampling,
@@ -106,6 +40,44 @@ const TravelingSalesman = (props: Props) => {
         presenting,
         theme,
     ])
+
+    const tspRunning = props.cities.cities.length > 0 && !presenting
+    useAnimationLoop(tspRunning ? 60 : null, () => {
+        const maxBound = (time: number, size: number) => {
+            let t = time % (2 * size)
+            return t < size ? t : size
+        }
+        const minBound = (time: number, size: number) => {
+            let t = time % (2 * size)
+            return t < size ? 0 : time % size
+        }
+        const n = nRef.current
+        let min = minBound(n, props.numberColors + 1)
+        let max = maxBound(n, props.numberColors + 1)
+        let citiesToDraw = props.cities.cities.slice(min * 2, max * 2)
+
+        const context: CanvasRenderingContext2D =
+            canvas.current.getContext('2d')!
+        const width = canvas.current.width
+        const height = canvas.current.height
+        context.save()
+        context.clearRect(0, 0, width, height)
+        context.fillStyle = theme.theme.background
+        context.fillRect(0, 0, width, height)
+        context.beginPath()
+        context.strokeStyle = theme.theme.middleground
+        context.lineWidth = 5
+        for (let i = 0; i < citiesToDraw.length; i += 2) {
+            context.lineTo(
+                Math.floor((width * citiesToDraw[i]) / props.squareSampling),
+                Math.floor(
+                    (height * citiesToDraw[i + 1]) / props.squareSampling
+                )
+            )
+        }
+        context.stroke()
+        nRef.current += 1
+    })
 
     let style = {}
 

--- a/src/bits/voronoi/Voronoi.tsx
+++ b/src/bits/voronoi/Voronoi.tsx
@@ -5,9 +5,9 @@ import { getRandomInt, getXYfromIndex, getBrightness } from '../../utils'
 import './Voronoi.css'
 import * as d3 from 'd3'
 import { Delaunay } from 'd3-delaunay'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
-import { ThemeContext } from "../../ThemeContext"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
+import Loader from '../../Presentation'
+import { ThemeContext } from '../../ThemeContext'
 
 import './Voronoi.css'
 
@@ -43,6 +43,7 @@ const Voronoi = (props: Props) => {
     const [canvasWidth, setCanvasWidth] = useState(0)
     const [canvasHeight, setCanvasHeight] = useState(0)
     const [presenting, setPresenting] = useState(props.delay > 0)
+    const [done, setDone] = useState(false)
 
     useTimeout(() => {
         setPresenting(false)
@@ -126,109 +127,91 @@ const Voronoi = (props: Props) => {
         }
     }, [props.width, props.height])
 
+    const updatesRef = useRef(0)
+    const citiesCopyRef = useRef<Cities | undefined>(undefined)
     useEffect(() => {
-        if (cities !== undefined && !presenting) {
-            const getRadius = (d: City) => {
-                return 2 + 1 * getBrightness(d.r, d.g, d.b)
-            }
-
-            const sitesUpdate = (
-                sites: Array<City>,
-                imageData: Array<City>,
-                width: number,
-                height: number
-            ): Array<City> => {
-                const delaunay = Delaunay.from(
-                    sites,
-                    function (d) {
-                        return d.x
-                    },
-                    function (d) {
-                        return d.y
-                    }
-                )
-                const voronoi = delaunay.voronoi([0, 0, width, height])
-                const diagram = voronoi.cellPolygons()
-                let newSites: Array<City> = getCentroids(diagram).map(function (
-                    centroid,
-                    index
-                ) {
-                    let closestIndex =
-                        Math.floor(centroid[1]) * width +
-                        Math.floor(centroid[0])
-                    let closestPixel = imageData[closestIndex]
-
-                    const newCity: City = {
-                        x: centroid[0],
-                        y: centroid[1],
-                        r: closestPixel.r,
-                        g: closestPixel.g,
-                        b: closestPixel.b,
-                    }
-                    return newCity
-                })
-                return newSites
-            }
-
-            let updates = 0
-            let timeoutId: any
-            let citiesCopy = JSON.parse(JSON.stringify(cities))
-
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    const context: CanvasRenderingContext2D =
-                        canvas.current.getContext('2d')!
-                    let canvasWidth = canvas.current.width
-                    let canvasHeight = canvas.current.height
-                    context.clearRect(0, 0, canvasWidth, canvasHeight)
-
-                    citiesCopy.sites.forEach(function (d: City) {
-                        context.beginPath()
-                        if (theme.theme.name === 'light') {
-                            context.fillStyle = `${d3.rgb(+d.r, +d.g, +d.b)}`
-                        } else if (theme.theme.name === 'dark') {
-                            context.fillStyle = `${d3.rgb(
-                                255 - +d.r,
-                                255 - +d.g,
-                                255 - +d.b
-                            )}`
-                        } else {
-                            context.fillStyle = `rgba(255, 0, 255, ${getBrightness(
-                                +d.r,
-                                +d.g,
-                                +d.b
-                            )})`
-                        }
-                        let x = (+d.x / citiesCopy.imageWidth) * canvasWidth
-                        let y = (+d.y / citiesCopy.imageHeight) * canvasHeight
-                        let r = (getRadius(d) * canvasWidth) / 800
-                        context.arc(x, y, r, 0, 2 * Math.PI)
-                        context.fill()
-                    })
-                    if (updates < 10) {
-                        citiesCopy.sites = sitesUpdate(
-                            citiesCopy.sites,
-                            citiesCopy.totalData,
-                            citiesCopy.imageWidth,
-                            citiesCopy.imageHeight
-                        )
-                        updates += 1
-                        frameId = requestAnimationFrame(animate)
-                    }
-                }, 1000 / 10)
-            }
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
-            }
-        }
+        updatesRef.current = 0
+        citiesCopyRef.current = cities
+            ? JSON.parse(JSON.stringify(cities))
+            : undefined
+        setDone(false)
     }, [cities, presenting, theme])
+
+    const voronoiRunning = cities !== undefined && !presenting && !done
+    useAnimationLoop(voronoiRunning ? 10 : null, () => {
+        const getRadius = (d: City) => {
+            return 2 + 1 * getBrightness(d.r, d.g, d.b)
+        }
+
+        const sitesUpdate = (
+            sites: Array<City>,
+            imageData: Array<City>,
+            width: number,
+            height: number
+        ): Array<City> => {
+            const delaunay = Delaunay.from(
+                sites,
+                (d) => d.x,
+                (d) => d.y
+            )
+            const voronoi = delaunay.voronoi([0, 0, width, height])
+            const diagram = voronoi.cellPolygons()
+            return getCentroids(diagram).map((centroid) => {
+                let closestIndex =
+                    Math.floor(centroid[1]) * width + Math.floor(centroid[0])
+                let closestPixel = imageData[closestIndex]
+                return {
+                    x: centroid[0],
+                    y: centroid[1],
+                    r: closestPixel.r,
+                    g: closestPixel.g,
+                    b: closestPixel.b,
+                }
+            })
+        }
+
+        const citiesCopy = citiesCopyRef.current!
+        const context: CanvasRenderingContext2D =
+            canvas.current.getContext('2d')!
+        let canvasWidth = canvas.current.width
+        let canvasHeight = canvas.current.height
+        context.clearRect(0, 0, canvasWidth, canvasHeight)
+
+        citiesCopy.sites.forEach(function (d: City) {
+            context.beginPath()
+            if (theme.theme.name === 'light') {
+                context.fillStyle = `${d3.rgb(+d.r, +d.g, +d.b)}`
+            } else if (theme.theme.name === 'dark') {
+                context.fillStyle = `${d3.rgb(
+                    255 - +d.r,
+                    255 - +d.g,
+                    255 - +d.b
+                )}`
+            } else {
+                context.fillStyle = `rgba(255, 0, 255, ${getBrightness(
+                    +d.r,
+                    +d.g,
+                    +d.b
+                )})`
+            }
+            let x = (+d.x / citiesCopy.imageWidth) * canvasWidth
+            let y = (+d.y / citiesCopy.imageHeight) * canvasHeight
+            let r = (getRadius(d) * canvasWidth) / 800
+            context.arc(x, y, r, 0, 2 * Math.PI)
+            context.fill()
+        })
+        if (updatesRef.current < 10) {
+            citiesCopy.sites = sitesUpdate(
+                citiesCopy.sites,
+                citiesCopy.totalData,
+                citiesCopy.imageWidth,
+                citiesCopy.imageHeight
+            )
+            updatesRef.current += 1
+        } else {
+            setDone(true)
+        }
+    })
 
     let isVertical = props.height / props.width < 1
 

--- a/src/util/Animation.tsx
+++ b/src/util/Animation.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect, useContext } from 'react'
 import { colorToInt, colorToGrayscale } from '../utils'
-import { useTimeout } from '../Hooks'
+import { useTimeout, useAnimationLoop } from '../Hooks'
 import Loader from '../Presentation'
 import { ThemeContext } from '../ThemeContext'
 import './Animation.css'
@@ -75,79 +75,59 @@ const Animation = (props: Props) => {
         }
     }, [props.res])
 
+    const countRef = useRef(0)
     useEffect(() => {
-        if (color !== undefined && position !== undefined && !presenting) {
-            let count = 0
-            let timeoutId: any
+        countRef.current = 0
+    }, [color, position, presenting, theme])
 
-            const animate = () => {
-                // Wrapping the animation function wiht a timeout makes it
-                // possible to control the fps, without losing the benefits of
-                // requestAnimationFrame.
-                timeoutId = setTimeout(function () {
-                    const context: CanvasRenderingContext2D =
-                        canvas.current.getContext('2d', {
-                            willReadFrequently: true,
-                        })!
-                    context.imageSmoothingEnabled = false
-                    let canvasWidth = canvas.current.width
-                    let canvasHeight = canvas.current.height
-                    context.clearRect(0, 0, canvasWidth, canvasHeight)
-                    let frame = context.getImageData(
-                        0,
-                        0,
-                        canvasWidth,
-                        canvasHeight
-                    )
+    const ready = color !== undefined && position !== undefined && !presenting
+    useAnimationLoop(ready ? 10 : null, () => {
+        const context: CanvasRenderingContext2D = canvas.current.getContext(
+            '2d',
+            { willReadFrequently: true }
+        )!
+        context.imageSmoothingEnabled = false
+        let canvasWidth = canvas.current.width
+        let canvasHeight = canvas.current.height
+        context.clearRect(0, 0, canvasWidth, canvasHeight)
+        let frame = context.getImageData(0, 0, canvasWidth, canvasHeight)
 
-                    let l = frame.data.length / 4
+        let l = frame.data.length / 4
 
-                    for (let i = 0; i < l; i++) {
-                        let index = (i + count) % l
+        for (let i = 0; i < l; i++) {
+            let index = (i + countRef.current) % l
 
-                        let r = position!.data[index * 4 + 0]
-                        let g = position!.data[index * 4 + 1]
-                        let b = position!.data[index * 4 + 2]
-                        let j = colorToInt(r, g, b)
+            let r = position!.data[index * 4 + 0]
+            let g = position!.data[index * 4 + 1]
+            let b = position!.data[index * 4 + 2]
+            let j = colorToInt(r, g, b)
 
-                        if (theme.theme.name == 'konami') {
-                            let luminance = colorToGrayscale(
-                                color!.data[i * 4 + 0],
-                                color!.data[i * 4 + 1],
-                                color!.data[i * 4 + 2]
-                            )
-                            frame.data[j * 4 + 0] = 255
-                            frame.data[j * 4 + 1] = luminance
-                            frame.data[j * 4 + 2] = 255
-                            frame.data[j * 4 + 3] = 255
-                        } else if (theme.theme.name == 'light') {
-                            frame.data[j * 4 + 0] = 255 - color!.data[i * 4 + 0]
-                            frame.data[j * 4 + 1] = 255 - color!.data[i * 4 + 1]
-                            frame.data[j * 4 + 2] = 255 - color!.data[i * 4 + 2]
-                            frame.data[j * 4 + 3] = 255
-                        } else {
-                            frame.data[j * 4 + 0] = color!.data[i * 4 + 0]
-                            frame.data[j * 4 + 1] = color!.data[i * 4 + 1]
-                            frame.data[j * 4 + 2] = color!.data[i * 4 + 2]
-                            frame.data[j * 4 + 3] = 255
-                        }
-                    }
-                    context.putImageData(frame, 0, 0)
-
-                    frameId = requestAnimationFrame(animate)
-                    count += 512
-                }, 1000 / 10)
-            }
-
-            let frameId: number | null = requestAnimationFrame(animate)
-            return () => {
-                cancelAnimationFrame(frameId!)
-                // It is important to clean up after the component unmounts.
-                clearTimeout(timeoutId)
-                frameId = null
+            if (theme.theme.name == 'konami') {
+                let luminance = colorToGrayscale(
+                    color!.data[i * 4 + 0],
+                    color!.data[i * 4 + 1],
+                    color!.data[i * 4 + 2]
+                )
+                frame.data[j * 4 + 0] = 255
+                frame.data[j * 4 + 1] = luminance
+                frame.data[j * 4 + 2] = 255
+                frame.data[j * 4 + 3] = 255
+            } else if (theme.theme.name == 'light') {
+                frame.data[j * 4 + 0] = 255 - color!.data[i * 4 + 0]
+                frame.data[j * 4 + 1] = 255 - color!.data[i * 4 + 1]
+                frame.data[j * 4 + 2] = 255 - color!.data[i * 4 + 2]
+                frame.data[j * 4 + 3] = 255
+            } else {
+                frame.data[j * 4 + 0] = color!.data[i * 4 + 0]
+                frame.data[j * 4 + 1] = color!.data[i * 4 + 1]
+                frame.data[j * 4 + 2] = color!.data[i * 4 + 2]
+                frame.data[j * 4 + 3] = 255
             }
         }
-    }, [color, position, presenting, theme])
+        context.putImageData(frame, 0, 0)
+
+        countRef.current += 512
+    })
 
     let style = {}
     if (props.width > 0 && props.height > 0) {


### PR DESCRIPTION
## Summary

- Every bit was hand-rolling the same throttled rAF idiom (`setTimeout(() => { ...work...; rAF(animate) }, 1000 / fps)`). Extracted into a single `useAnimationLoop(fps, callback)` hook in `Hooks.tsx`, with `fps == null` to pause.
- Migrated all 17 call sites (16 bits + `util/Animation.tsx`). 18 files, +799 / −1099.
- For Three.js bits with effect-local resources (scene/renderer/etc.), introduced a small `tickRef` convention: the setup `useEffect` builds resources and assigns the per-frame work to a ref; the hook drives the loop reading from it. Keeps closures local without needing to hoist every resource into its own ref.
- Voronoi (which auto-stops after 10 update frames) gates via a `done` state that flips `fps` to `null`.

Motivation: prep for the per-bit speed control flagged as out-of-scope in ADR 003. With one timer location, threading `speed` through becomes a single-seam change.

## Test plan

- [x] Conway smoke test (Conway-style migration, simplest case).
- [x] Click-through visual check of all migrated bits — no regressions vs main.
- [ ] Verify Voronoi's auto-stop still triggers after 10 frames (it should freeze on the final cell layout).
- [ ] Verify Three.js bits (Anaglyph, Penrose, Corrupted, Julia, Autostereogram) still tear down cleanly on navigation.
- [ ] Verify recordable bits still record cleanly via `/record` (Conway, Voronoi, Mandelbrot, Penrose, Corrupted, etc.).