### PR TITLE
✨ Per-bit speed control via slider in the recorder

### DIFF
--- a/docs/decisions/003-in-browser-bit-recorder.md
+++ b/docs/decisions/003-in-browser-bit-recorder.md
@@ -91,6 +91,14 @@ The bottom-of-screen progress bar copies Panama's `scrub`/`scrubFill` styling (3
 
 We briefly tried a pulsing-disc animation on the record button during recording. Reverted to a simple disabled-state opacity dim — consistent with the rest of the chrome and with the project's "no smooth transitions" convention. The bottom progress bar carries all timing feedback.
 
+### Animation speed control via `BitSpeedContext` + `useAnimationLoop`
+
+Speed is exposed in the recorder as a 0–3× slider (default 1, 0 pauses) and scales the rate of every bit's animation loop without per-bit prop plumbing. A `BitSpeedContext` (defaulting to 1) is read inside a shared `useAnimationLoop(fps, callback)` hook that all bits use for their throttled animation. The recorder wraps its bit host in a provider with the chosen speed; the hook multiplies the bit's declared fps by the context value.
+
+This required first extracting `useAnimationLoop` from the repeated `setTimeout + rAF` idiom that every bit was hand-rolling (PR #27). That cleanup left a single seam to thread speed through. The alternative — adding a `speed` prop to each bit's interface — would have meant per-bit edits and ~15 lines of `speed={1}` plumbing in `Home.tsx`. Context kept the change to two files: the hook and the recorder (PR #28).
+
+When the target rate (`fps × speed`) exceeds the display refresh, the hook batches multiple callbacks per `requestAnimationFrame` fire. Without this, high-fps bits (Conway, traveling-salesman) would plateau at the rAF ceiling and "3×" would silently mean "1×" for them.
+
 ## Consequences
 
 -   A new owner-gated route at `poroto.<host>/record`.
@@ -98,10 +106,10 @@ We briefly tried a pulsing-disc animation on the record button during recording.
 -   Two Three.js bits now create renderers with `preserveDrawingBuffer: true`. This has a minor performance cost — required for capture.
 -   A new `src/recorder/` directory with the registry, the recording hook, and the backend-fed wrappers. Recorder UI is `src/Recorder.tsx` / `src/Recorder.css`.
 -   The `RecordableBit` interface is the canonical list of "things we want to share on social." When new bits are added, they should be registered here (or explicitly excluded).
+-   `BitSpeedContext` (in `Hooks.tsx`) is the contract between any animation-loop consumer and a speed-aware wrapper. The recorder is the only current producer; all other call sites get the default value of 1.
 
 ## Out of Scope (Future)
 
--   **Animation speed control.** Each bit owns its own timing primitives (rAF + setTimeout throttles, internal accumulators, Three.js clocks). Adding a uniform `speed` prop requires per-bit changes and was deferred — flagged for a follow-up.
 -   **Audio capture.** Bits don't have audio yet.
 -   **Custom durations beyond 5/10/15/30 seconds.**
 -   **Stories/Reels-specific presets** beyond square and portrait.

--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -44,31 +44,44 @@ export function useRequestAnimationFrame(animateCallback) {
     }, [animateCallback])
 }
 
+// Multiplier applied to every useAnimationLoop call's fps. 1 = normal, 0 = paused.
+export const BitSpeedContext = createContext(1)
+
 // Frame-aligned animation loop capped at `fps`. Pass fps=null to pause.
+// Effective rate is `fps * speed`, where speed comes from BitSpeedContext.
 export function useAnimationLoop(fps, callback) {
     const savedCallback = useRef(callback)
+    const speed = useContext(BitSpeedContext)
 
     useEffect(() => {
         savedCallback.current = callback
     }, [callback])
 
     useEffect(() => {
-        if (fps == null) return
-        const interval = 1000 / fps
+        if (fps == null || speed <= 0) return
+        const stepMs = 1000 / (fps * speed)
+        // If the target rate exceeds display refresh, batch multiple callbacks
+        // per fire instead of trying to fire faster than the screen can paint.
+        const FRAME_MS = 16
+        const callsPerFire =
+            stepMs < FRAME_MS ? Math.ceil(FRAME_MS / stepMs) : 1
+        const fireDelay = Math.max(stepMs, 1)
         let frameId = null
         let timeoutId = null
         const tick = () => {
             timeoutId = setTimeout(() => {
-                savedCallback.current()
+                for (let i = 0; i < callsPerFire; i++) {
+                    savedCallback.current()
+                }
                 frameId = requestAnimationFrame(tick)
-            }, interval)
+            }, fireDelay)
         }
         frameId = requestAnimationFrame(tick)
         return () => {
             if (frameId != null) cancelAnimationFrame(frameId)
             if (timeoutId != null) clearTimeout(timeoutId)
         }
-    }, [fps])
+    }, [fps, speed])
 }
 
 export function useTimeout(callback, delay) {

--- a/src/Recorder.css
+++ b/src/Recorder.css
@@ -66,6 +66,60 @@
     cursor: not-allowed;
 }
 
+.Recorder-speedRow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 16px 12px;
+}
+
+.Recorder-speedValue {
+    font-family: inherit;
+    font-size: 12px;
+    color: #161011;
+    opacity: 0.6;
+    min-width: 40px;
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}
+
+.Recorder-speedSlider {
+    -webkit-appearance: none;
+    appearance: none;
+    flex: 1;
+    height: 3px;
+    background: rgba(255, 0, 255, 0.12);
+    outline: none;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+}
+
+.Recorder-speedSlider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: magenta;
+    cursor: pointer;
+    border: none;
+}
+
+.Recorder-speedSlider::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: magenta;
+    cursor: pointer;
+    border: none;
+}
+
+.Recorder-speedSlider:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+}
+
 .Recorder-stage {
     flex: 1;
     display: flex;

--- a/src/Recorder.tsx
+++ b/src/Recorder.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, Suspense } from 'react'
 import { recordableBits } from './recorder/bitRegistry'
 import { useRecording } from './recorder/useRecording'
+import { BitSpeedContext } from './Hooks'
 import './Recorder.css'
 
 const FORMATS = {
@@ -18,6 +19,7 @@ const Recorder = () => {
     const [bitSlug, setBitSlug] = useState(recordableBits[0].slug)
     const [format, setFormat] = useState<Format>('square')
     const [duration, setDuration] = useState<number>(10)
+    const [speed, setSpeed] = useState<number>(1)
     const [recordingKey, setRecordingKey] = useState(0)
 
     const bitContainerRef = useRef<HTMLDivElement>(null)
@@ -88,6 +90,20 @@ const Recorder = () => {
                     ))}
                 </div>
             </div>
+            <div className="Recorder-speedRow">
+                <input
+                    type="range"
+                    min={0}
+                    max={3}
+                    step={0.05}
+                    value={speed}
+                    onChange={(e) => setSpeed(Number(e.target.value))}
+                    disabled={controlsDisabled}
+                    className="Recorder-speedSlider"
+                    aria-label="speed"
+                />
+                <span className="Recorder-speedValue">{speed.toFixed(2)}×</span>
+            </div>
 
             <div className="Recorder-stage">
                 <div className={`Recorder-frame Recorder-frame-${format}`}>
@@ -100,23 +116,25 @@ const Recorder = () => {
                 </div>
             </div>
 
-            <div
-                ref={bitContainerRef}
-                className="Recorder-bitHost"
-                style={{ width, height }}
-            >
-                <Suspense fallback={null}>
-                    <BitComponent
-                        key={`${bitSlug}-${recordingKey}`}
-                        title={bit.name}
-                        delay={0}
-                        style={{}}
-                        width={width}
-                        height={height}
-                        {...(bit.extraProps ?? {})}
-                    />
-                </Suspense>
-            </div>
+            <BitSpeedContext.Provider value={speed}>
+                <div
+                    ref={bitContainerRef}
+                    className="Recorder-bitHost"
+                    style={{ width, height }}
+                >
+                    <Suspense fallback={null}>
+                        <BitComponent
+                            key={`${bitSlug}-${recordingKey}`}
+                            title={bit.name}
+                            delay={0}
+                            style={{}}
+                            width={width}
+                            height={height}
+                            {...(bit.extraProps ?? {})}
+                        />
+                    </Suspense>
+                </div>
+            </BitSpeedContext.Provider>
 
             <div className="Recorder-footer">
                 <button

--- a/src/bits/nostalgia/Nostalgia.tsx
+++ b/src/bits/nostalgia/Nostalgia.tsx
@@ -7,13 +7,13 @@ import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js'
 import { TexturePass } from 'three/examples/jsm/postprocessing/TexturePass.js'
 import './Nostalgia.css'
 import boxer from '../../assets/boxer.jpg'
-import { useTimeout } from "../../Hooks"
-import Loader from "../../Presentation"
+import { useTimeout, useAnimationLoop } from '../../Hooks'
+import Loader from '../../Presentation'
 
 import * as tf from '@tensorflow/tfjs'
 import * as blazeface from '@tensorflow-models/blazeface'
 
-import { ThemeContext } from "../../ThemeContext"
+import { ThemeContext } from '../../ThemeContext'
 import CSS from 'csstype'
 
 import {
@@ -83,88 +83,82 @@ const Nostalgia = (props: Props) => {
             })
     }, [])
 
+    const tickRef = useRef(() => {})
     useEffect(() => {
-        if (!presenting && predictions.length > 0) {
-            let cancel = false
-            const renderer = new THREE.WebGLRenderer({
-                canvas: canvas.current,
-            })
-            renderer.setPixelRatio(window.devicePixelRatio)
-            renderer.setClearColor(0x000000)
+        if (presenting || predictions.length === 0) return
+        const renderer = new THREE.WebGLRenderer({
+            canvas: canvas.current,
+            preserveDrawingBuffer: true,
+        })
+        renderer.setPixelRatio(window.devicePixelRatio)
+        renderer.setClearColor(0x000000)
 
-            let aspectRatioImage = height / width
-            let aspectRatioFrame = props.height / props.width
-            let isVertical = aspectRatioFrame > 1
-            let style
+        let aspectRatioImage = height / width
+        let aspectRatioFrame = props.height / props.width
+        let isVertical = aspectRatioFrame > 1
 
-            const parameters = {
-                minFilter: THREE.LinearFilter,
-                magFilter: THREE.LinearFilter,
-                format: THREE.RGBAFormat,
-                stencilBuffer: true,
-            }
+        const parameters = {
+            minFilter: THREE.LinearFilter,
+            magFilter: THREE.LinearFilter,
+            format: THREE.RGBAFormat,
+            stencilBuffer: true,
+        }
 
-            let renderTarget
+        let renderTarget
 
-            if (isVertical) {
-                renderer.setSize(props.width, props.width * aspectRatioImage)
-                renderTarget = new THREE.WebGLRenderTarget(
-                    props.width,
-                    props.width * aspectRatioImage,
-                    parameters
-                )
-            } else {
-                renderer.setSize(props.height / aspectRatioImage, props.height)
-                renderTarget = new THREE.WebGLRenderTarget(
-                    props.height / aspectRatioImage,
-                    props.height,
-                    parameters
-                )
-            }
-
-            const magentaPass = new ShaderPass(
-                colorMatrixShader(theme.theme.colorMatrix)
-            )
-            const myMaskPass = new MaskPass(
-                32,
+        if (isVertical) {
+            renderer.setSize(props.width, props.width * aspectRatioImage)
+            renderTarget = new THREE.WebGLRenderTarget(
                 props.width,
+                props.width * aspectRatioImage,
+                parameters
+            )
+        } else {
+            renderer.setSize(props.height / aspectRatioImage, props.height)
+            renderTarget = new THREE.WebGLRenderTarget(
+                props.height / aspectRatioImage,
                 props.height,
-                width,
-                height,
-                predictions
+                parameters
             )
-            myMaskPass.goWild = false
+        }
 
-            const texture = new THREE.TextureLoader().load(boxer)
-            texture.minFilter = THREE.LinearFilter
-            const texturePass = new TexturePass(texture)
+        const magentaPass = new ShaderPass(
+            colorMatrixShader(theme.theme.colorMatrix)
+        )
+        const myMaskPass = new MaskPass(
+            32,
+            props.width,
+            props.height,
+            width,
+            height,
+            predictions
+        )
+        myMaskPass.goWild = false
 
-            const dotScreenPass = new DotScreenPass(
-                new THREE.Vector2(0.5, 0.5),
-                1.57,
-                0.8
-            )
-            const copyPass = new ShaderPass(CopyShader)
-            copyPass.renderToScreen = true
-            const composer = new EffectComposer(renderer, renderTarget)
+        const texture = new THREE.TextureLoader().load(boxer)
+        texture.minFilter = THREE.LinearFilter
+        const texturePass = new TexturePass(texture)
 
-            composer.addPass(texturePass)
-            composer.addPass(dotScreenPass)
-            composer.addPass(myMaskPass)
-            composer.addPass(magentaPass)
-            composer.addPass(copyPass)
+        const dotScreenPass = new DotScreenPass(
+            new THREE.Vector2(0.5, 0.5),
+            1.57,
+            0.8
+        )
+        const copyPass = new ShaderPass(CopyShader)
+        copyPass.renderToScreen = true
+        const composer = new EffectComposer(renderer, renderTarget)
 
-            const animate = () => {
-                requestAnimationFrame(animate)
-                composer.render()
-            }
+        composer.addPass(texturePass)
+        composer.addPass(dotScreenPass)
+        composer.addPass(myMaskPass)
+        composer.addPass(magentaPass)
+        composer.addPass(copyPass)
 
-            let frameId: number | null = requestAnimationFrame(animate)
-
-            return () => {
-                cancelAnimationFrame(frameId!)
-                frameId = null
-            }
+        tickRef.current = () => {
+            composer.render()
+        }
+        return () => {
+            tickRef.current = () => {}
         }
     }, [
         props.width,
@@ -175,6 +169,9 @@ const Nostalgia = (props: Props) => {
         width,
         height,
     ])
+
+    const nostalgiaRunning = !presenting && predictions.length > 0
+    useAnimationLoop(nostalgiaRunning ? 60 : null, () => tickRef.current())
 
     if (presenting) {
         return <Loader title={props.title} />


### PR DESCRIPTION
## Summary

- Adds a `BitSpeedContext` that scales the rate of every `useAnimationLoop` call. Recorder wraps its bit host in the provider; all bits respond automatically via the shared hook — no per-bit prop plumbing.
- New slider in the recorder header: range 0–3×, default 1×, step 0.05. 0 pauses.
- When the requested rate exceeds the display refresh, the hook batches multiple callbacks per fire so high-fps bits (Conway, TSP, etc.) actually accelerate instead of plateauing at the rAF ceiling.
- Migrates **Nostalgia** to `useAnimationLoop` — it was the one recordable bit still on the pure-rAF pattern and therefore deaf to the slider. Also adds `preserveDrawingBuffer: true` to its renderer so it doesn't flash the cleared canvas at low speeds.

Implements the speed-control follow-up flagged out-of-scope in ADR 003.

## Test plan

- [x] Slider drag responds smoothly across the full 0–3× range.
- [x] Conway accelerates visibly at 3× (verifies multi-call-per-fire batching).
- [x] Distrito (1986) doesn't freeze at high speeds (verifies the batching doesn't runaway on heavy bits).
- [x] Nostalgia respects the slider; no flicker at speed < 1.
- [ ] Record a clip at 2× and verify the output mp4 is twice as fast as 1×.
- [ ] Record a clip at 0.5× and verify it's half-speed.
- [ ] Verify slider value `0` pauses the bit and resumes when raised.